### PR TITLE
Add option to normalize beamformer weights

### DIFF
--- a/examples/general_beamforming_weights.ipynb
+++ b/examples/general_beamforming_weights.ipynb
@@ -116,7 +116,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(12, 4))\n",
-    "plot_beampattern_azimuth(plane_wave_dencomposition, azi, label='N = {}'.format(N))"
+    "plot_beampattern_azimuth(plane_wave_dencomposition, azi, label=f'N = {N}')"
    ]
   },
   {
@@ -136,9 +136,11 @@
    "source": [
     "R_dB = 50\n",
     "R = 10**(R_dB/20)\n",
-    "d_nm_sidelobe = spharpy.beamforming.dolph_chebyshev_weights(N, R, design_criterion='sidelobe')\n",
+    "d_nm_sidelobe = spharpy.beamforming.dolph_chebyshev_weights(\n",
+    "    N, R, design_criterion='sidelobe')\n",
     "theta0 = np.pi/6\n",
-    "d_nm_mainlobe = spharpy.beamforming.dolph_chebyshev_weights(N, theta0, design_criterion='mainlobe')"
+    "d_nm_mainlobe = spharpy.beamforming.dolph_chebyshev_weights(\n",
+    "    N, theta0, design_criterion='mainlobe')"
    ]
   },
   {
@@ -158,8 +160,10 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(12, 4))\n",
-    "plot_beampattern_azimuth(dolph_cheby_sidelobe, azi, label='N = {}, R = {} dB'.format(N, R_dB))\n",
-    "plot_beampattern_azimuth(dolph_cheby_mainlobe, azi, label='N = {}, $\\\\theta_0$ = {} $\\\\pi$'.format(N, np.round(theta0/np.pi, decimals=3)), linestyle='dotted', colorbar=False)\n",
+    "plot_beampattern_azimuth(\n",
+    "    dolph_cheby_sidelobe, azi, label=f'N = {N}, R = {R_dB} dB')\n",
+    "plot_beampattern_azimuth(\n",
+    "    dolph_cheby_mainlobe, azi, label='N = {}, $\\\\theta_0$ = {} $\\\\pi$'.format(N, np.round(theta0/np.pi, decimals=3)), linestyle='dotted', colorbar=False)\n",
     "plt.axhline(-R_dB, color='k', linestyle='-.', alpha=0.7)\n",
     "plt.axvline(theta0+doa.azimuth, color='k', linestyle='-.', alpha=0.7)\n",
     "plt.axvline(doa.azimuth-theta0, color='k', linestyle='-.', alpha=0.7)"
@@ -189,7 +193,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(12, 4))\n",
-    "plot_beampattern_azimuth(re_max/re_max.max(), azi, label='N = {}'.format(N))"
+    "plot_beampattern_azimuth(re_max, azi, label=f'N = {N}')"
    ]
   },
   {
@@ -214,7 +218,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "h_n = hann(2*(N+1)+1)[N+1:-1]\n",
+    "h_n = spharpy.beamforming.normalize_beamforming_weights(\n",
+    "    hann(2*(N+1)+1)[N+1:-1], N)\n",
     "h_nm = spharpy.indexing.sph_identity_matrix(N).T @ h_n\n",
     "hanning = np.squeeze(Y_steering @ np.diag(h_nm) @ p_nm.T)"
    ]
@@ -226,7 +231,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(12, 4))\n",
-    "plot_beampattern_azimuth(hanning/hanning.max(), azi, label='N = {}'.format(N))"
+    "plot_beampattern_azimuth(hanning, azi, label=f'N = {N}')"
    ]
   },
   {
@@ -261,7 +266,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(12, 4))\n",
-    "plot_beampattern_azimuth(max_fb, azi, label='N = {}'.format(N))\n",
+    "plot_beampattern_azimuth(max_fb, azi, label=f'N = {N}')\n",
     "plt.axvline(doa.azimuth+np.pi/2, color='k', linestyle='-.', alpha=0.7)\n",
     "plt.axvline(doa.azimuth-np.pi/2, color='k', linestyle='-.', alpha=0.7)"
    ]
@@ -286,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/spharpy/beamforming/__init__.py
+++ b/spharpy/beamforming/__init__.py
@@ -1,11 +1,13 @@
 from .beamforming import (
     dolph_chebyshev_weights,
     rE_max_weights,
-    maximum_front_back_ratio_weights
+    maximum_front_back_ratio_weights,
+    normalize_beamforming_weights
 )
 
 __all__ = [
     'dolph_chebyshev_weights',
     'rE_max_weights',
     'maximum_front_back_ratio_weights',
+    'normalize_beamforming_weights'
 ]

--- a/spharpy/beamforming/beamforming.py
+++ b/spharpy/beamforming/beamforming.py
@@ -1,3 +1,4 @@
+import itertools
 import numpy as np
 import numpy.polynomial as poly
 from scipy.linalg import eig
@@ -143,17 +144,14 @@ def maximum_front_back_ratio_weights(n_max, normalize=True):
     for n in range(n_max+1):
         for n_dash in range(n_max+1):
             const = 1/8/np.pi * (2*n+1) * (2*n_dash+1)
-            temp = 0
-            for q in range(n+1):
-                for ll in range(n_dash+1):
-                    temp += 1/(q+ll+1) * P_N[q, n] * P_N[ll, n_dash]
+            temp = sum(
+                1 / (q+ll+1) * P_N[q, n] * P_N[ll, n_dash]
+                for q, ll in itertools.product(range(n+1), range(n_dash+1)))
             Ann[n, n_dash] = temp * const
 
-            temp = 0
-            for q in range(n+1):
-                for ll in range(n_dash+1):
-                    temp += ((-1)**(q+ll))/(q+ll+1) * \
-                        P_N[q, n] * P_N[ll, n_dash]
+            temp = sum(
+                ((-1) ** (q+ll)) / (q+ll+1) * P_N[q, n] * P_N[ll, n_dash]
+                for q, ll in itertools.product(range(n+1), range(n_dash+1)))
             Bnn[n, n_dash] = temp * const
 
     eigenvals, eigenvectors = eig(Ann, Bnn)

--- a/spharpy/beamforming/beamforming.py
+++ b/spharpy/beamforming/beamforming.py
@@ -1,7 +1,7 @@
 import itertools
 import numpy as np
 import numpy.polynomial as poly
-from scipy.linalg import eig
+from scipy.linalg import eigh
 from scipy.special import factorial
 
 import spharpy
@@ -154,7 +154,12 @@ def maximum_front_back_ratio_weights(n_max, normalize=True):
                 for q, ll in itertools.product(range(n+1), range(n_dash+1)))
             Bnn[n, n_dash] = temp * const
 
-    eigenvals, eigenvectors = eig(Ann, Bnn)
+    try:
+        eigenvals, eigenvectors = eigh(Ann, Bnn)
+    except np.linalg.LinAlgError as e:
+        raise RuntimeError(
+            'Eigenvalue decomposition did not converge. '
+            'Try reducing the spherical harmonic order.') from e
     f_n = eigenvectors[:, np.argmax(np.real(eigenvals))]
     if normalize:
         f_n = normalize_beamforming_weights(f_n, n_max)

--- a/spharpy/beamforming/beamforming.py
+++ b/spharpy/beamforming/beamforming.py
@@ -109,7 +109,7 @@ def rE_max_weights(n_max, normalize=True):
     return spharpy.indexing.sph_identity_matrix(n_max).T @ g_n
 
 
-def maximum_front_back_ratio_weights(n_max):
+def maximum_front_back_ratio_weights(n_max, normalize=True):
     """Weights that maximize the front-back ratio of the beam pattern.
     This is also often referred to as the super-cardioid beam pattern.
 
@@ -117,6 +117,9 @@ def maximum_front_back_ratio_weights(n_max):
     ----------
     n_max : int
         The spherical harmonic order
+    normalize : bool
+        If `True`, the weights will be normalized such that the complex
+        amplitude of a plane wave is not distorted.
 
     Returns
     -------
@@ -142,20 +145,21 @@ def maximum_front_back_ratio_weights(n_max):
         for n_dash in range(n_max+1):
             const = 1/8/np.pi * (2*n+1) * (2*n_dash+1)
             temp = 0
-            for q in range(0, n+1):
-                for ll in range(0, n_dash+1):
+            for q in range(n+1):
+                for ll in range(n_dash+1):
                     temp += 1/(q+ll+1) * P_N[q, n] * P_N[ll, n_dash]
             Ann[n, n_dash] = temp * const
 
             temp = 0
-            for q in range(0, n+1):
-                for ll in range(0, n_dash+1):
+            for q in range(n+1):
+                for ll in range(n_dash+1):
                     temp += ((-1)**(q+ll))/(q+ll+1) * \
                         P_N[q, n] * P_N[ll, n_dash]
             Bnn[n, n_dash] = temp * const
 
     eigenvals, eigenvectors = eig(Ann, Bnn)
     f_n = eigenvectors[:, np.argmax(np.real(eigenvals))]
-    weights = spharpy.indexing.sph_identity_matrix(n_max).T @ f_n
+    if normalize:
+        f_n /= np.dot(f_n, 2*np.arange(0, n_max+1)+1)/(4*np.pi)
 
-    return weights
+    return spharpy.indexing.sph_identity_matrix(n_max).T @ f_n

--- a/spharpy/beamforming/beamforming.py
+++ b/spharpy/beamforming/beamforming.py
@@ -71,8 +71,7 @@ def dolph_chebyshev_weights(
 
     return weights
 
-
-def rE_max_weights(n_max):
+def rE_max_weights(n_max, normalize=True):
     """Weights that maximize the length of the energy vector.
     This is most often used in Ambisonics decoding.
 
@@ -80,6 +79,9 @@ def rE_max_weights(n_max):
     ----------
     n_max : int
         Spherical harmonic order
+    normalize : bool
+        If `True`, the weights will be normalized such that the complex
+        amplitude of a plane wave is not distorted.
 
     Returns
     -------
@@ -97,13 +99,14 @@ def rE_max_weights(n_max):
     P_n_root = poly.legendre.legroots(leg.coef)
     max_root = np.max(np.abs(P_n_root))
     g_n = np.zeros(n_max+1)
-    for n in range(0, n_max+1):
+    for n in range(n_max+1):
         leg = poly.legendre.Legendre.basis(n)
         g_n[n] = leg(max_root)
 
-    weights = spharpy.indexing.sph_identity_matrix(n_max).T @ g_n
+    if normalize:
+        g_n /= np.dot(g_n, 2*np.arange(0, n_max+1)+1)/(4*np.pi)
 
-    return weights
+    return spharpy.indexing.sph_identity_matrix(n_max).T @ g_n
 
 
 def maximum_front_back_ratio_weights(n_max):

--- a/spharpy/beamforming/beamforming.py
+++ b/spharpy/beamforming/beamforming.py
@@ -104,7 +104,7 @@ def rE_max_weights(n_max, normalize=True):
         g_n[n] = leg(max_root)
 
     if normalize:
-        g_n /= np.dot(g_n, 2*np.arange(0, n_max+1)+1)/(4*np.pi)
+        g_n = normalize_beamforming_weights(g_n, n_max)
 
     return spharpy.indexing.sph_identity_matrix(n_max).T @ g_n
 
@@ -157,6 +157,28 @@ def maximum_front_back_ratio_weights(n_max, normalize=True):
     eigenvals, eigenvectors = eig(Ann, Bnn)
     f_n = eigenvectors[:, np.argmax(np.real(eigenvals))]
     if normalize:
-        f_n /= np.dot(f_n, 2*np.arange(0, n_max+1)+1)/(4*np.pi)
+        f_n = normalize_beamforming_weights(f_n, n_max)
+    else:
+        f_n /= np.sign(f_n[0])
 
     return spharpy.indexing.sph_identity_matrix(n_max).T @ f_n
+
+
+def normalize_beamforming_weights(weights, n_max):
+    """Normalize the beamforming weights such that the complex amplitude of a
+    plane wave is not distorted.
+
+    Parameters
+    ----------
+    weights : ndarray, double
+        An array containing the beamforming weights
+    n_max : int
+        The spherical harmonic order
+
+    Returns
+    -------
+    weights : ndarray, double
+        An array containing the normalized beamforming weights
+
+    """
+    return weights / np.dot(weights, 2*np.arange(0, n_max+1)+1) * (4*np.pi)

--- a/spharpy/beamforming/beamforming.py
+++ b/spharpy/beamforming/beamforming.py
@@ -67,9 +67,8 @@ def dolph_chebyshev_weights(
                            (1/2**j)*t_2N[2*j]*P_N[i, n]*x0**(2*j)
         d_n[n] = (2*np.pi/R)*temp
 
-    weights = spharpy.indexing.sph_identity_matrix(n_max, type='n-nm').T @ d_n
+    return spharpy.indexing.sph_identity_matrix(n_max, type='n-nm').T @ d_n
 
-    return weights
 
 def rE_max_weights(n_max, normalize=True):
     """Weights that maximize the length of the energy vector.

--- a/tests/test_beamforming.py
+++ b/tests/test_beamforming.py
@@ -41,7 +41,16 @@ def test_re_max():
 
 def test_max_front_back():
     N = 7
-    f_nm = spharpy.beamforming.maximum_front_back_ratio_weights(N)
+    f_nm = spharpy.beamforming.maximum_front_back_ratio_weights(
+        N, normalize=False)
 
     truth = np.loadtxt('tests/data/max_front_back_weights.csv', delimiter=',')
     npt.assert_allclose(f_nm, truth)
+
+    f_nm_norm = spharpy.beamforming.maximum_front_back_ratio_weights(
+        N, normalize=True)
+
+    Y = spharpy.spherical.spherical_harmonic_basis_real(
+        N, spharpy.samplings.Coordinates(1, 0, 0))
+
+    npt.assert_allclose(Y @ np.diag(f_nm_norm) @ Y.T, 1)

--- a/tests/test_beamforming.py
+++ b/tests/test_beamforming.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 import spharpy
 
@@ -42,12 +43,6 @@ def test_re_max():
 
 def test_max_front_back():
     N = 7
-    f_nm = spharpy.beamforming.maximum_front_back_ratio_weights(
-        N, normalize=False)
-
-    truth = np.loadtxt('tests/data/max_front_back_weights.csv', delimiter=',')
-    npt.assert_allclose(f_nm, np.abs(truth))
-
     f_nm_norm = spharpy.beamforming.maximum_front_back_ratio_weights(
         N, normalize=True)
 
@@ -55,3 +50,6 @@ def test_max_front_back():
         N, spharpy.samplings.Coordinates(1, 0, 0))
 
     npt.assert_allclose(Y @ np.diag(f_nm_norm) @ Y.T, 1)
+
+    with pytest.raises(RuntimeError, match='did not converge'):
+        spharpy.beamforming.maximum_front_back_ratio_weights(30)

--- a/tests/test_beamforming.py
+++ b/tests/test_beamforming.py
@@ -26,10 +26,17 @@ def test_dolph_cheby_sidelobe():
 
 def test_re_max():
     N = 7
-    g_nm = spharpy.beamforming.rE_max_weights(N)
+    g_nm = spharpy.beamforming.rE_max_weights(N, normalize=False)
 
     truth = np.loadtxt('tests/data/re_max_weights.csv', delimiter=',')
     npt.assert_allclose(g_nm, truth)
+
+    g_nm_norm = spharpy.beamforming.rE_max_weights(N, normalize=True)
+
+    Y = spharpy.spherical.spherical_harmonic_basis_real(
+        N, spharpy.samplings.Coordinates(1, 0, 0))
+
+    npt.assert_allclose(Y @ np.diag(g_nm_norm) @ Y.T, 1)
 
 
 def test_max_front_back():

--- a/tests/test_beamforming.py
+++ b/tests/test_beamforming.py
@@ -46,7 +46,7 @@ def test_max_front_back():
         N, normalize=False)
 
     truth = np.loadtxt('tests/data/max_front_back_weights.csv', delimiter=',')
-    npt.assert_allclose(f_nm, truth)
+    npt.assert_allclose(f_nm, np.abs(truth))
 
     f_nm_norm = spharpy.beamforming.maximum_front_back_ratio_weights(
         N, normalize=True)

--- a/tests/test_beamforming.py
+++ b/tests/test_beamforming.py
@@ -53,3 +53,14 @@ def test_max_front_back():
 
     with pytest.raises(RuntimeError, match='did not converge'):
         spharpy.beamforming.maximum_front_back_ratio_weights(30)
+
+
+def test_normalize_weights():
+    n_max = 7
+    normalized_weights = spharpy.beamforming.normalize_beamforming_weights(
+        np.ones(n_max+1), n_max)
+
+    # pwd weights are const 4*pi/(n_max+1)**2
+    expected = np.ones(n_max+1)*4*np.pi/(n_max+1)**2
+
+    npt.assert_allclose(expected, normalized_weights)

--- a/tests/test_beamforming.py
+++ b/tests/test_beamforming.py
@@ -3,6 +3,7 @@ import numpy.testing as npt
 
 import spharpy
 
+
 def test_dolph_cheby_mainlobe():
     N = 7
     theta0 = np.pi/6


### PR DESCRIPTION
Add the option to normalise the beamforming weights such that they fulfil the distortionless response property.

- [x] implement normalisation function
- [x] maximum front-back ratio
- [x] max rE
- [x] update example notebook

Also fixes a phase error in max-fb-ratio when the eigenvector corresponding to the largest eigenvalue is negative.