### PR TITLE
link to contributer page in authors

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,6 +2,6 @@
 Credits
 =======
 
-The pyfar `developers`_.
+The spharpy `developers`_.
 
 .. _developers: https://github.com/pyfar/spharpy/graphs/contributors

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,4 +2,6 @@
 Credits
 =======
 
-The pyfar developers <info@pyfar.org>
+The pyfar `developers`_.
+
+.. _developers: https://github.com/pyfar/spharpy/graphs/contributors


### PR DESCRIPTION
would replace #56 
just link to [contributors](https://github.com/pyfar/spharpy/graphs/contributors) instead of pyfar dev
we should reconsider it for pyfar again