### PR TITLE
fix pyfar dependency

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,7 +19,7 @@ pytest-runner
 numpydoc
 autodocsumm
 nbmake
-pyfar<0.6.0
+pyfar<0.8.0
 pydata-sphinx-theme
 sphinx-design
 sphinx-favicon

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     'scipy',
     'urllib3',
     'matplotlib>=3.3.0',
-    'pyfar<0.6.0',
+    'pyfar<0.8.0',
 ]
 
 setup_requirements = [


### PR DESCRIPTION
spharpy works as long as the old functionality of coordiantes is working in pyfar. They will be removed in pyfar 0.8.0.
right now its not possible to use pyfar 0.6.4 with spahrpy..., this would fix it