### PR TITLE
fix matplotlib deprecation

### DIFF
--- a/examples/spherical_harmonics.ipynb
+++ b/examples/spherical_harmonics.ipynb
@@ -27,7 +27,7 @@
     "        n, m = spharpy.spherical.acn2nm(acn)\n",
     "        idx_m = int(np.floor(n_max/2+1)) + m\n",
     "        ax = plt.subplot(gs[n, idx_m], projection='3d')\n",
-    "        balloon = spharpy.plot.balloon_wireframe(sampling, Y[:, acn], phase=True, show=False, colorbar=False, ax=ax)\n",
+    "        balloon = spharpy.plot.balloon_wireframe(sampling, Y[:, acn], phase=True, colorbar=False, ax=ax)\n",
     "        ax.set_title('$Y_{' + str(n) + '}^{' + str(m) + '}(\\\\theta, \\\\phi)$')\n",
     "        plt.axis('off')\n",
     "    cax = plt.subplot(gs[n_max+1, :])\n",
@@ -376,7 +376,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/spharpy/plot/cmap.py
+++ b/spharpy/plot/cmap.py
@@ -1,4 +1,4 @@
-from matplotlib import cm
+import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
 import numpy as np
 
@@ -8,7 +8,7 @@ def phase_twilight(lut=512):
     version of the twilight color map from matplotlib.
     """
     lut = int(np.ceil(lut/4)*4)
-    twilight = cm.get_cmap('twilight', lut=lut)
+    twilight = plt.get_cmap('twilight', lut=lut)
 
     twilight_r_colors = np.array(twilight.reversed().colors)
 

--- a/spharpy/plot/spatial.py
+++ b/spharpy/plot/spatial.py
@@ -272,7 +272,7 @@ def pcolor_sphere(
     else:
         itype = 'amplitude'
         if cmap is None:
-            cmap = cm.viridis
+            cmap = plt.get_cmap('viridis')
         clabel = 'Amplitude'
 
     cdata, vmin, vmax = _balloon_color_data(tri, data, itype)
@@ -355,7 +355,7 @@ def balloon_wireframe(
     else:
         itype = 'amplitude'
         if cmap is None:
-            cmap = cm.viridis
+            cmap = plt.get_cmap('viridis')
         clabel = 'Amplitude'
 
     cdata, vmin, vmax = _balloon_color_data(tri, data, itype)
@@ -452,7 +452,7 @@ def balloon(
     else:
         itype = 'amplitude'
         if cmap is None:
-            cmap = cm.viridis
+            cmap = plt.get_cmap('viridis')
         clabel = 'Amplitude'
 
     cdata, vmin, vmax = _balloon_color_data(tri, data, itype)
@@ -676,7 +676,7 @@ def contour_map(
         data,
         projection='mollweide',
         limits=None,
-        cmap=cm.viridis,
+        cmap=plt.get_cmap('viridis'),
         colorbar=True,
         show=True,
         levels=None,
@@ -757,7 +757,7 @@ def contour_map(
 
 
 def contour(
-        coordinates, data, limits=None, cmap=cm.viridis, show=True, ax=None):
+        coordinates, data, limits=None, cmap=plt.get_cmap('viridis'), show=True, ax=None):
     """
     Plot the map projection of data points sampled on a spherical surface.
     The data has to be real-valued.

--- a/spharpy/plot/spatial.py
+++ b/spharpy/plot/spatial.py
@@ -43,7 +43,7 @@ def set_aspect_equal_3d(ax):
     ax.set_zlim3d([zmean - plot_radius, zmean + plot_radius])
 
 
-def scatter(coordinates, ax=None, show=True):
+def scatter(coordinates, ax=None):
     """Plot the x, y, and z coordinates of the sampling grid in the 3d space.
 
     Parameters
@@ -69,9 +69,6 @@ def scatter(coordinates, ax=None, show=True):
         np.ptp(coordinates.x),
         np.ptp(coordinates.y),
         np.ptp(coordinates.z)])
-
-    if show:
-        plt.show()
 
 
 def _triangulation_sphere(sampling, data):
@@ -223,7 +220,6 @@ def pcolor_sphere(
         data,
         cmap=None,
         colorbar=True,
-        show=True,
         phase=False,
         ax=None,
         *args,
@@ -251,8 +247,6 @@ def pcolor_sphere(
     ax : matplotlib.axis, None, optional
         The matplotlib axis object used for plotting. By default `None`, which
         will create a new axis object.
-    show : boolean, optional
-        Whether to show the figure or not
 
     """ # noqa: 501
     coordinates = convert_coordinates(coordinates)
@@ -299,9 +293,6 @@ def pcolor_sphere(
         np.ptp(coordinates.y),
         np.ptp(coordinates.z)])
 
-    if show:
-        plt.show()
-
     return plot
 
 
@@ -310,7 +301,6 @@ def balloon_wireframe(
         data,
         cmap=None,
         phase=False,
-        show=True,
         colorbar=True,
         ax=None):
     """Plot data on a sphere defined by the coordinate angles
@@ -335,8 +325,6 @@ def balloon_wireframe(
     phase : boolean, optional
         Encode the phase of the data in the colormap. This option will be
         activated by default of the data is complex valued.
-    show : boolean, optional
-        Whether to show the figure or not
     """ # noqa: 501
     coordinates = convert_coordinates(coordinates)
     tri, xyz = _triangulation_sphere(coordinates, data)
@@ -390,9 +378,6 @@ def balloon_wireframe(
         np.ptp(xyz[1]),
         np.ptp(xyz[2])])
 
-    if show:
-        plt.show()
-
     plot.set_facecolor([0.9, 0.9, 0.9, 0.9])
 
     return plot
@@ -403,7 +388,6 @@ def balloon(
         data,
         cmap=None,
         phase=False,
-        show=True,
         colorbar=True,
         ax=None,
         *args,
@@ -431,8 +415,6 @@ def balloon(
     phase : boolean, optional
         Encode the phase of the data in the colormap. This option will be
         activated by default of the data is complex valued.
-    show : boolean, optional
-        Wheter to show the figure or not
     """ # noqa: 501
     coordinates = convert_coordinates(coordinates)
 
@@ -480,9 +462,6 @@ def balloon(
     ax.set_xlabel('x[m]')
     ax.set_ylabel('y[m]')
     ax.set_zlabel('z[m]')
-
-    if show:
-        plt.show()
 
     return plot
 
@@ -598,7 +577,6 @@ def pcolor_map(
         projection='mollweide',
         limits=None,
         cmap=plt.get_cmap('viridis'),
-        show=True,
         refine=False,
         ax=None,
         **kwargs):
@@ -618,8 +596,6 @@ def pcolor_map(
     data: ndarray, double
         Data for each angle, must have size corresponding to the number of
         points given in coordinates.
-    show : boolean, optional
-        Wheter to show the figure or not
 
     """ # noqa: 501
     coordinates = convert_coordinates(coordinates)
@@ -666,8 +642,6 @@ def pcolor_map(
     plt.grid(True)
     cb = fig.colorbar(cf, ax=ax, extend=extend)
     cb.set_label('Amplitude')
-    if show:
-        plt.show()
 
     return cf
 
@@ -679,7 +653,6 @@ def contour_map(
         limits=None,
         cmap=plt.get_cmap('viridis'),
         colorbar=True,
-        show=True,
         levels=None,
         ax=None):
     """
@@ -700,8 +673,6 @@ def contour_map(
     data: ndarray, double
         Data for each angle, must have size corresponding to the number of
         points given in coordinates.
-    show : boolean, optional
-        Wheter to show the figure or not
 
     """
     coordinates = convert_coordinates(coordinates)
@@ -751,15 +722,13 @@ def contour_map(
     if colorbar:
         cb = fig.colorbar(cf, ax=ax, ticks=levels)
         cb.set_label('Amplitude')
-    if show:
-        plt.show()
 
     return cf
 
 
 def contour(
         coordinates, data, limits=None, cmap=plt.get_cmap('viridis'),
-        show=True, ax=None):
+        ax=None):
     """
     Plot the map projection of data points sampled on a spherical surface.
     The data has to be real-valued.
@@ -776,8 +745,6 @@ def contour(
     data: ndarray, double
         Data for each angle, must have size corresponding to the number of
         points given in coordinates.
-    show : boolean, optional
-        Wheter to show the figure or not
 
     """ # noqa: 501
     coordinates = convert_coordinates(coordinates)
@@ -794,8 +761,6 @@ def contour(
     plt.grid(True)
     cb = fig.colorbar(cf, ax=ax)
     cb.set_label('Amplitude')
-    if show:
-        plt.show()
 
     return cf
 

--- a/spharpy/plot/spatial.py
+++ b/spharpy/plot/spatial.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import matplotlib.tri as mtri
 import numpy as np
 import scipy.spatial as sspat
-from matplotlib import cm, colors
+from matplotlib import colors
 from mpl_toolkits.mplot3d import Axes3D
 __all__ = [Axes3D]
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
@@ -43,7 +43,7 @@ def set_aspect_equal_3d(ax):
     ax.set_zlim3d([zmean - plot_radius, zmean + plot_radius])
 
 
-def scatter(coordinates, ax=None):
+def scatter(coordinates, ax=None, show=True):
     """Plot the x, y, and z coordinates of the sampling grid in the 3d space.
 
     Parameters
@@ -70,7 +70,8 @@ def scatter(coordinates, ax=None):
         np.ptp(coordinates.y),
         np.ptp(coordinates.z)])
 
-    plt.show()
+    if show:
+        plt.show()
 
 
 def _triangulation_sphere(sampling, data):
@@ -757,7 +758,8 @@ def contour_map(
 
 
 def contour(
-        coordinates, data, limits=None, cmap=plt.get_cmap('viridis'), show=True, ax=None):
+        coordinates, data, limits=None, cmap=plt.get_cmap('viridis'),
+        show=True, ax=None):
     """
     Plot the map projection of data points sampled on a spherical surface.
     The data has to be real-valued.

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -19,9 +19,9 @@ def test_balloon_plot(icosahedron, make_coordinates, implementation):
     coords = make_coordinates.create_coordinates(
         implementation, rad, theta, phi)
     data = np.cos(phi)*np.sin(theta)
-    spharpy.plot.balloon(coords, data, show=False)
+    spharpy.plot.balloon(coords, data)
 
-    spharpy.plot.balloon(coords, data, phase=True, show=False)
+    spharpy.plot.balloon(coords, data, phase=True)
 
 
 @pytest.mark.parametrize("implementation", ['spharpy', 'pyfar'])
@@ -31,7 +31,7 @@ def test_contour_plot(icosahedron, make_coordinates, implementation):
         implementation, rad, theta, phi)
     data = np.cos(phi)*np.sin(theta)
 
-    spharpy.plot.contour(coords, np.abs(data), show=False)
+    spharpy.plot.contour(coords, np.abs(data))
 
 
 @pytest.mark.parametrize("implementation", ['spharpy', 'pyfar'])


### PR DESCRIPTION
- test are failing atm
- ``matplotlib.cm.COLORMAP`` is deprecated.
- remove ``plt.show()`` in plot module, i was thinking this was the reson for the failing notebook
- notebook is still failing, now idea why, maybe we just stick to older versions of matplotlib