### PR TITLE
Nm to fuma

### DIFF
--- a/spharpy/spherical.py
+++ b/spharpy/spherical.py
@@ -88,7 +88,7 @@ def nm2acn(n, m):
     return n**2 + n + m
 
 
-def nm2fuma(n, m):
+def nm_to_fuma(n, m):
     r"""
     Calculate the FuMa channel index for a given spherical harmonic order n
     and degree m, according to the FuMa (Furse-Malham)
@@ -109,16 +109,25 @@ def nm2fuma(n, m):
 
     fuma_mapping = [0, 2, 3, 1, 8, 6, 4, 5, 7, 15, 13, 11, 9, 10, 12, 14]
 
+    n = np.asarray([n], dtype=int)
+    m = np.asarray([m], dtype=int)
+
+    if n.shape != m.shape:
+        raise ValueError("n and m need to be of the same size")
+
     # convert (n, m) to the ACN index
     acn = nm2acn(n, m)
 
-    if acn < 0 or acn >= len(fuma_mapping):
+    if np.any(acn < 0) or np.any(acn >= len(fuma_mapping)):
         raise ValueError(
             "nm2fuma only supports up to 3rd order"
         )
 
-    # convert to fuma
-    fuma = fuma_mapping.index(acn)
+    acn = np.atleast_2d(acn).T
+    fuma = np.array([], dtype=int)
+    for a in acn:
+        fuma = np.append(fuma, fuma_mapping.index(a))
+
     return fuma
 
 

--- a/spharpy/spherical.py
+++ b/spharpy/spherical.py
@@ -88,6 +88,40 @@ def nm2acn(n, m):
     return n**2 + n + m
 
 
+def nm2fuma(n, m):
+    r"""
+    Calculate the FuMa channel index for a given spherical harmonic order n
+    and degree m, according to the FuMa (Furse-Malham)
+    Channel Ordering Convention.
+
+    Parameters
+    ----------
+    n : integer
+        Spherical harmonic order
+    m : integer
+        Spherical harmonic degree
+
+    Returns
+    -------
+    fuma : integer
+        FuMa channel index
+    """
+
+    fuma_mapping = [0, 2, 3, 1, 8, 6, 4, 5, 7, 15, 13, 11, 9, 10, 12, 14]
+
+    # convert (n, m) to the ACN index
+    acn = nm2acn(n, m)
+
+    if acn < 0 or acn >= len(fuma_mapping):
+        raise ValueError(
+            "nm2fuma only supports up to 3rd order"
+        )
+
+    # convert to fuma
+    fuma = fuma_mapping.index(acn)
+    return fuma
+
+
 def spherical_harmonic_basis(n_max, coords):
     r"""
     Calculates the complex valued spherical harmonic basis matrix.

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -83,3 +83,8 @@ def test_sid2acn():
 
     acn_indices = sh.sid2acn(n_max)
     np.testing.assert_equal(reference_acn, acn_indices)
+
+
+def test_nm2fuma_signle_val():
+    fuma = sh.nm2fuma(0, 0)
+    assert fuma == 0

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -89,9 +89,18 @@ def test_nm2fuma_single_val():
     fuma = sh.nm2fuma(0, 0)
     assert fuma == 0
 
-    fuma = sh.nm2acn(1, 0)
-    assert fuma == 2
+    fuma = sh.nm2fuma(1, 0)
+    assert fuma == 1
 
-    fuma = sh.nm2acn(1, -1)
+    fuma = sh.nm2fuma(1, -1)
     assert fuma == 3
 
+
+def test_nm2fuma_array():
+    n = np.array([0, 1, 1])
+    m = np.array([0, 0, -1])
+
+    fuma = sh.nm2fuma(n, m)
+    assert fuma[0] == 0
+    assert fuma[1] == 1
+    assert fuma[2] == 3

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -101,6 +101,4 @@ def test_nm2fuma_array():
     m = np.array([0, 0, -1])
 
     fuma = sh.nm_to_fuma(n, m)
-    assert fuma[0] == 0
-    assert fuma[1] == 1
-    assert fuma[2] == 3
+    np.testing.assert_equal(np.array([0, 1, 3], int), fuma)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -86,13 +86,13 @@ def test_sid2acn():
 
 
 def test_nm2fuma_single_val():
-    fuma = sh.nm2fuma(0, 0)
+    fuma = sh.nm_to_fuma(0, 0)
     assert fuma == 0
 
-    fuma = sh.nm2fuma(1, 0)
+    fuma = sh.nm_to_fuma(1, 0)
     assert fuma == 1
 
-    fuma = sh.nm2fuma(1, -1)
+    fuma = sh.nm_to_fuma(1, -1)
     assert fuma == 3
 
 
@@ -100,7 +100,7 @@ def test_nm2fuma_array():
     n = np.array([0, 1, 1])
     m = np.array([0, 0, -1])
 
-    fuma = sh.nm2fuma(n, m)
+    fuma = sh.nm_to_fuma(n, m)
     assert fuma[0] == 0
     assert fuma[1] == 1
     assert fuma[2] == 3

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -85,6 +85,13 @@ def test_sid2acn():
     np.testing.assert_equal(reference_acn, acn_indices)
 
 
-def test_nm2fuma_signle_val():
+def test_nm2fuma_single_val():
     fuma = sh.nm2fuma(0, 0)
     assert fuma == 0
+
+    fuma = sh.nm2acn(1, 0)
+    assert fuma == 2
+
+    fuma = sh.nm2acn(1, -1)
+    assert fuma == 3
+


### PR DESCRIPTION
Implement a method to convert from nm to fuma index in the same way as the fuma2nm method from `dev_spherical_harmonics_class` branch