### PR TITLE
Reduce test time

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,3 +49,16 @@ def icosahedron():
     rad = np.ones(20)
 
     return rad, theta, phi
+
+
+@pytest.fixture
+def download_sampling():
+    def download_sampling(kind, degree):
+        if kind in ['extremal', 'hyperinterpolation']:
+            from spharpy.samplings.samplings import _sph_extremal_load_data
+            return _sph_extremal_load_data(degree)
+        elif kind == 't-design':
+            from spharpy.samplings.samplings import _sph_t_design_load_data
+            return _sph_t_design_load_data(degree)
+
+    return download_sampling

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -4,7 +4,7 @@ import spharpy.interpolate as interpolate
 import numpy as np
 
 
-def test_smooth_sphere_bivariate_spline_interpolation():
+def test_smooth_sphere_bivariate_spline_interpolation(download_sampling):
     n_max = 10
     sampling = spharpy.samplings.equal_area(
         n_max, n_points=500, condition_num=np.inf)
@@ -15,6 +15,7 @@ def test_smooth_sphere_bivariate_spline_interpolation():
 
     data = np.sin(sampling.colatitude)*np.sin(2*sampling.azimuth)
 
+    download_sampling('extremal', 35)
     interp_grid = spharpy.samplings.hyperinterpolation(n_max=35)
 
     data_grid = np.sin(interp_grid.colatitude)*np.sin(2*interp_grid.azimuth)

--- a/tests/test_samplings.py
+++ b/tests/test_samplings.py
@@ -30,16 +30,16 @@ def test_cube_equidistant_pyfar():
     assert c.csize == 3*2*4
 
 
-def test_hyperinterpolation():
+def test_hyperinterpolation(download_sampling):
     n_max = 1
-    samplings.samplings._sph_extremal_load_data(n_max)
+    download_sampling('hyperinterpolation', n_max)
     sampling = samplings.hyperinterpolation(n_max=n_max)
     assert sampling.radius.size == (n_max+1)**2
 
 
-def test_sph_extremal():
+def test_sph_extremal(download_sampling):
     # load test data
-    samplings.samplings._sph_extremal_load_data([1, 10])
+    download_sampling('hyperinterpolation', [1, 10])
 
     # test without parameters
     assert samplings.hyperinterpolation() is None
@@ -74,32 +74,32 @@ def test_sph_extremal():
         c = samplings.hyperinterpolation(n_max=0)
 
 
-def test_spherical_t_design_const_e():
+def test_spherical_t_design_const_e(download_sampling):
     order = 2
-    samplings.samplings._sph_t_design_load_data(range(1, 11))
+    download_sampling('t-design', np.arange(1, 11))
     coords = samplings.spherical_t_design(
         n_max=order, criterion='const_energy')
     assert isinstance(coords, SamplingSphere)
 
 
-def test_spherical_t_design_const_angle():
+def test_spherical_t_design_const_angle(download_sampling):
     order = 2
-    samplings.samplings._sph_t_design_load_data(range(1, 11))
+    download_sampling('t-design', np.arange(1, 11))
     coords = samplings.spherical_t_design(
         n_max=order, criterion='const_angular_spread')
     assert isinstance(coords, SamplingSphere)
 
 
-def test_spherical_t_design_invalid():
+def test_spherical_t_design_invalid(download_sampling):
     order = 2
-    samplings.samplings._sph_t_design_load_data(range(1, 11))
+    download_sampling('t-design', np.arange(1, 11))
     with pytest.raises(ValueError, match='Invalid design'):
         samplings.spherical_t_design(n_max=order, criterion='bla')
 
 
-def test_sph_t_design():
+def test_sph_t_design(download_sampling):
     # load test data
-    samplings.samplings._sph_t_design_load_data(np.arange(1, 11))
+    download_sampling('t-design', np.arange(1, 11))
 
     # test without parameters
     assert samplings.spherical_t_design() is None

--- a/tests/test_samplings_interior.py
+++ b/tests/test_samplings_interior.py
@@ -14,10 +14,9 @@ def test_sph_bessel_zeros():
 
 
 def test_interior_points_chardon():
-    kr_max = 7
+    kr_max = 4
     int_points = samplings.interior_stabilization_points(kr_max)
 
-    filename = 'tests/data/interior_points_kr7.csv'
-    truth = np.genfromtxt(filename, dtype=float, delimiter=';')
+    truth = np.array([[0, 0, 0]], dtype=float)
 
     np.testing.assert_allclose(int_points.cartesian, truth, atol=1e-7)


### PR DESCRIPTION
CircleCI aborts tests and times out during downloads of the sampling files and long operations

- create fixture to download files for hyperinterpolation and t-design samplings
- download only required files
- reduce the kr-limit for the testing of interior stabilization points