### PR TITLE
cookiecutter: fix np.array to scalar deprecation warning

### DIFF
--- a/spharpy/samplings/helpers.py
+++ b/spharpy/samplings/helpers.py
@@ -206,7 +206,7 @@ def spherical_voronoi(sampling, round_decimals=13, center=0.0):
     if len(radius) > 1:
         raise ValueError("All sampling points need to be on the \
                 same radius.")
-    voronoi = SphericalVoronoi(points, radius, center)
+    voronoi = SphericalVoronoi(points, radius[0], center)
 
     return voronoi
 


### PR DESCRIPTION
fix for

`DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)`