### PR TITLE
fix matplotlib version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,13 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    
+
 ]
 dependencies = [
     'numpy>=1.22',
     'scipy',
     'urllib3',
-    'matplotlib>=3.3.0',
+    'matplotlib>=3.10.3',
     'pyfar<0.8.0',
     'pytz',
 ]
@@ -48,7 +48,7 @@ tests = [
     "watchdog",
     "ruff==0.8.3",
     "coverage",
-    
+
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #91 

### Changes proposed in this pull request:

Force matplotlib version >= 3.10.3 to avoid error using contour map plots. Unfortunately it seems that this does not work vor Python 3.9