### PR TITLE
Check sum of weights in SamplingSphere

### DIFF
--- a/spharpy/samplings/coordinates.py
+++ b/spharpy/samplings/coordinates.py
@@ -41,9 +41,9 @@ class SamplingSphere(pf.Coordinates):
             self, x, y, z, weights=weights, comment=comment)
         self._n_max = n_max
 
-        self.weights.__doc__ = (
-            "The area or quadrature weights of the sampling. "
-            "Their sum must be equal to 4*pi.")
+        # self.weights.__doc__ = (
+        #     "The area or quadrature weights of the sampling. "
+        #     "Their sum must be equal to 4*pi.")
 
     @classmethod
     def from_cartesian(
@@ -315,28 +315,14 @@ class SamplingSphere(pf.Coordinates):
         else:
             self._n_max = int(value)
 
-    def _set_weights(self, weights):
-        """Check and set sampling weights.
+    def _check_weights(self, weights):
+        weights = super()._check_weights(weights)
 
-        Set self._weights, which is an atleast_1d numpy array of shape
-        [L,M,...,N].
-
-        """
-        # check if weights is None
         if weights is None:
-            self._weights = weights
-            return
-
-        weights = np.asarray(weights, dtype=np.float64)
-
-        # reshape according to self._points
-        if weights.size != self.csize:
-            raise ValueError("Weights must have same size as csize.")
-        weights = weights.reshape(self.cshape)
-
-        if not np.isclose(np.sum(weights), 4*np.pi, atol=1e-6, rtol=1e-6):
+            return weights
+        elif not np.isclose(np.sum(weights), 4*np.pi, atol=1e-6, rtol=1e-6):
             raise ValueError(
                 "The sum of the weights must be equal to 4*pi. "
                 f"Current sum: {np.sum(weights)}")
 
-        self._weights = weights
+        return weights

--- a/spharpy/samplings/coordinates.py
+++ b/spharpy/samplings/coordinates.py
@@ -27,9 +27,11 @@ class SamplingSphere(pf.Coordinates):
             Z coordinate of a right handed Cartesian coordinate system in
             meters (-\infty < z < \infty).
         weights: array like, number, optional
-            Weighting factors for coordinate points. The `shape` of the array
-            must match the `shape` of the individual coordinate arrays.
-            The default is ``None``.
+            Weighting factors for coordinate points. Their sum must equal to
+            the integral over the unit sphere, which is :math:`4\pi`.
+            The `shape` of the array must match the `shape` of the individual
+            coordinate arrays. The default is ``None``, which means that not
+            weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
             ``""``, which initializes an empty string.
@@ -66,9 +68,11 @@ class SamplingSphere(pf.Coordinates):
             Maximum spherical harmonic order of the sampling grid.
             The default is ``None``.
         weights: array like, number, optional
-            Weighting factors for coordinate points. The `shape` of the array
-            must match the `shape` of the individual coordinate arrays.
-            The default is ``None``.
+            Weighting factors for coordinate points. Their sum must equal to
+            the integral over the unit sphere, which is :math:`4\pi`.
+            The `shape` of the array must match the `shape` of the individual
+            coordinate arrays. The default is ``None``, which means that not
+            weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
             ``""``, which initializes an empty string.
@@ -110,9 +114,11 @@ class SamplingSphere(pf.Coordinates):
             Maximum spherical harmonic order of the sampling grid.
             The default is ``None``.
         weights: array like, float, None, optional
-            Weighting factors for coordinate points. The `shape` of the array
-            must match the `shape` of the individual coordinate arrays.
-            The default is ``None``.
+            Weighting factors for coordinate points. Their sum must equal to
+            the integral over the unit sphere, which is :math:`4\pi`.
+            The `shape` of the array must match the `shape` of the individual
+            coordinate arrays. The default is ``None``, which means that not
+            weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
             ``""``, which initializes an empty string.
@@ -153,9 +159,11 @@ class SamplingSphere(pf.Coordinates):
             Maximum spherical harmonic order of the sampling grid.
             The default is ``None``.
         weights: array like, number, optional
-            Weighting factors for coordinate points. The `shape` of the array
-            must match the `shape` of the individual coordinate arrays.
-            The default is ``None``.
+            Weighting factors for coordinate points. Their sum must equal to
+            the integral over the unit sphere, which is :math:`4\pi`.
+            The `shape` of the array must match the `shape` of the individual
+            coordinate arrays. The default is ``None``, which means that not
+            weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
             ``""``, which initializes an empty string.
@@ -195,9 +203,11 @@ class SamplingSphere(pf.Coordinates):
             Maximum spherical harmonic order of the sampling grid.
             The default is ``None``.
         weights: array like, number, optional
-            Weighting factors for coordinate points. The `shape` of the array
-            must match the `shape` of the individual coordinate arrays.
-            The default is ``None``.
+            Weighting factors for coordinate points. Their sum must equal to
+            the integral over the unit sphere, which is :math:`4\pi`.
+            The `shape` of the array must match the `shape` of the individual
+            coordinate arrays. The default is ``None``, which means that not
+            weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
             ``""``, which initializes an empty string.
@@ -237,9 +247,11 @@ class SamplingSphere(pf.Coordinates):
             Maximum spherical harmonic order of the sampling grid.
             The default is ``None``.
         weights: array like, number, optional
-            Weighting factors for coordinate points. The `shape` of the array
-            must match the `shape` of the individual coordinate arrays.
-            The default is ``None``.
+            Weighting factors for coordinate points. Their sum must equal to
+            the integral over the unit sphere, which is :math:`4\pi`.
+            The `shape` of the array must match the `shape` of the individual
+            coordinate arrays. The default is ``None``, which means that not
+            weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
             ``""``, which initializes an empty string.
@@ -279,9 +291,11 @@ class SamplingSphere(pf.Coordinates):
             Maximum spherical harmonic order of the sampling grid.
             The default is ``None``.
         weights: array like, number, optional
-            Weighting factors for coordinate points. The `shape` of the array
-            must match the `shape` of the individual coordinate arrays.
-            The default is ``None``.
+            Weighting factors for coordinate points. Their sum must equal to
+            the integral over the unit sphere, which is :math:`4\pi`.
+            The `shape` of the array must match the `shape` of the individual
+            coordinate arrays. The default is ``None``, which means that not
+            weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
             ``""``, which initializes an empty string.

--- a/spharpy/samplings/coordinates.py
+++ b/spharpy/samplings/coordinates.py
@@ -41,10 +41,6 @@ class SamplingSphere(pf.Coordinates):
             self, x, y, z, weights=weights, comment=comment)
         self._n_max = n_max
 
-        # self.weights.__doc__ = (
-        #     "The area or quadrature weights of the sampling. "
-        #     "Their sum must be equal to 4*pi.")
-
     @classmethod
     def from_cartesian(
             cls, x, y, z, n_max=None, weights: np.array = None,
@@ -326,3 +322,17 @@ class SamplingSphere(pf.Coordinates):
                 f"Current sum: {np.sum(weights)}")
 
         return weights
+
+    @property
+    def weights(self):
+        """The area/quadrature weights of the sampling.
+        Their sum must equal to :math:`4\pi`.
+        """
+        return super().weights
+
+    @weights.setter
+    def weights(self, weights):
+        """The area/quadrature weights of the sampling.
+        Their sum must equal to :math:`4\pi`.
+        """
+        super(__class__, type(self)).weights.fset(self, weights)

--- a/spharpy/samplings/coordinates.py
+++ b/spharpy/samplings/coordinates.py
@@ -316,6 +316,9 @@ class SamplingSphere(pf.Coordinates):
 
         if weights is None:
             return weights
+        if np.any(weights < 0) or np.any(np.isnan(weights)):
+            raise ValueError("All weights must be positive numeric values.")
+
         elif not np.isclose(np.sum(weights), 4*np.pi, atol=1e-6, rtol=1e-6):
             raise ValueError(
                 "The sum of the weights must be equal to 4*pi. "

--- a/spharpy/samplings/coordinates.py
+++ b/spharpy/samplings/coordinates.py
@@ -41,6 +41,10 @@ class SamplingSphere(pf.Coordinates):
             self, x, y, z, weights=weights, comment=comment)
         self._n_max = n_max
 
+        self.weights.__doc__ = (
+            "The area or quadrature weights of the sampling. "
+            "Their sum must be equal to 4*pi.")
+
     @classmethod
     def from_cartesian(
             cls, x, y, z, n_max=None, weights: np.array = None,

--- a/spharpy/samplings/coordinates.py
+++ b/spharpy/samplings/coordinates.py
@@ -328,14 +328,14 @@ class SamplingSphere(pf.Coordinates):
 
     @property
     def weights(self):
-        """The area/quadrature weights of the sampling.
+        r"""The area/quadrature weights of the sampling.
         Their sum must equal to :math:`4\pi`.
         """
         return super().weights
 
     @weights.setter
     def weights(self, weights):
-        """The area/quadrature weights of the sampling.
+        r"""The area/quadrature weights of the sampling.
         Their sum must equal to :math:`4\pi`.
         """
         super(__class__, type(self)).weights.fset(self, weights)

--- a/spharpy/samplings/coordinates.py
+++ b/spharpy/samplings/coordinates.py
@@ -30,7 +30,7 @@ class SamplingSphere(pf.Coordinates):
             Weighting factors for coordinate points. Their sum must equal to
             the integral over the unit sphere, which is :math:`4\pi`.
             The `shape` of the array must match the `shape` of the individual
-            coordinate arrays. The default is ``None``, which means that not
+            coordinate arrays. The default is ``None``, which means that no
             weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
@@ -71,7 +71,7 @@ class SamplingSphere(pf.Coordinates):
             Weighting factors for coordinate points. Their sum must equal to
             the integral over the unit sphere, which is :math:`4\pi`.
             The `shape` of the array must match the `shape` of the individual
-            coordinate arrays. The default is ``None``, which means that not
+            coordinate arrays. The default is ``None``, which means that no
             weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
@@ -117,7 +117,7 @@ class SamplingSphere(pf.Coordinates):
             Weighting factors for coordinate points. Their sum must equal to
             the integral over the unit sphere, which is :math:`4\pi`.
             The `shape` of the array must match the `shape` of the individual
-            coordinate arrays. The default is ``None``, which means that not
+            coordinate arrays. The default is ``None``, which means that no
             weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
@@ -162,7 +162,7 @@ class SamplingSphere(pf.Coordinates):
             Weighting factors for coordinate points. Their sum must equal to
             the integral over the unit sphere, which is :math:`4\pi`.
             The `shape` of the array must match the `shape` of the individual
-            coordinate arrays. The default is ``None``, which means that not
+            coordinate arrays. The default is ``None``, which means that no
             weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
@@ -206,7 +206,7 @@ class SamplingSphere(pf.Coordinates):
             Weighting factors for coordinate points. Their sum must equal to
             the integral over the unit sphere, which is :math:`4\pi`.
             The `shape` of the array must match the `shape` of the individual
-            coordinate arrays. The default is ``None``, which means that not
+            coordinate arrays. The default is ``None``, which means that no
             weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
@@ -250,7 +250,7 @@ class SamplingSphere(pf.Coordinates):
             Weighting factors for coordinate points. Their sum must equal to
             the integral over the unit sphere, which is :math:`4\pi`.
             The `shape` of the array must match the `shape` of the individual
-            coordinate arrays. The default is ``None``, which means that not
+            coordinate arrays. The default is ``None``, which means that no
             weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is
@@ -294,7 +294,7 @@ class SamplingSphere(pf.Coordinates):
             Weighting factors for coordinate points. Their sum must equal to
             the integral over the unit sphere, which is :math:`4\pi`.
             The `shape` of the array must match the `shape` of the individual
-            coordinate arrays. The default is ``None``, which means that not
+            coordinate arrays. The default is ``None``, which means that no
             weights are used.
         comment : str, optional
             Comment about the stored coordinate points. The default is

--- a/spharpy/samplings/coordinates.py
+++ b/spharpy/samplings/coordinates.py
@@ -310,3 +310,29 @@ class SamplingSphere(pf.Coordinates):
             self._n_max = None
         else:
             self._n_max = int(value)
+
+    def _set_weights(self, weights):
+        """Check and set sampling weights.
+
+        Set self._weights, which is an atleast_1d numpy array of shape
+        [L,M,...,N].
+
+        """
+        # check if weights is None
+        if weights is None:
+            self._weights = weights
+            return
+
+        weights = np.asarray(weights, dtype=np.float64)
+
+        # reshape according to self._points
+        if weights.size != self.csize:
+            raise ValueError("Weights must have same size as csize.")
+        weights = weights.reshape(self.cshape)
+
+        if not np.isclose(np.sum(weights), 4*np.pi, atol=1e-6, rtol=1e-6):
+            raise ValueError(
+                "The sum of the weights must be equal to 4*pi. "
+                f"Current sum: {np.sum(weights)}")
+
+        self._weights = weights

--- a/spharpy/samplings/coordinates.py
+++ b/spharpy/samplings/coordinates.py
@@ -326,6 +326,21 @@ class SamplingSphere(pf.Coordinates):
             self._n_max = int(value)
 
     def _check_weights(self, weights):
+        r"""Check if the weights are valid.
+        The weights must be positive and their sum must equal integration of
+        the unit sphere, i.e. :math:`4\pi`.
+
+        Parameters
+        ----------
+        weights : array like, number
+            the weights for each point, should be of size of self.csize.
+
+        Returns
+        -------
+        weights : np.ndarray[float64], None
+            The weights reshaped to the cshape of the coordinates if not None.
+            Otherwise None.
+        """
         weights = super()._check_weights(weights)
 
         if weights is None:

--- a/spharpy/samplings/coordinates.py
+++ b/spharpy/samplings/coordinates.py
@@ -319,7 +319,7 @@ class SamplingSphere(pf.Coordinates):
         if np.any(weights < 0) or np.any(np.isnan(weights)):
             raise ValueError("All weights must be positive numeric values.")
 
-        elif not np.isclose(np.sum(weights), 4*np.pi, atol=1e-6, rtol=1e-6):
+        if not np.isclose(np.sum(weights), 4*np.pi, atol=1e-6, rtol=1e-6):
             raise ValueError(
                 "The sum of the weights must be equal to 4*pi. "
                 f"Current sum: {np.sum(weights)}")

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -1,4 +1,6 @@
 from spharpy import SamplingSphere
+import numpy as np
+import pytest
 
 
 def test_sampling_sphere_init():
@@ -53,21 +55,9 @@ def test_setting_weights_invalid():
     n_max = 1
     sampling = SamplingSphere(x, y, z, n_max)
 
-    weights = np.ones(5)*4*np.pi/6
-
-    # Check that setting weights with a different length raises an error
-    message = "Weights must have same size as csize."
-    with pytest.raises(ValueError, match=message):
-        sampling.weights = weights
-
     message = r"The sum of the weights must be equal to 4\*pi."
     with pytest.raises(ValueError, match=message):
         sampling.weights = np.ones(6)/6
-
-    # Check that setting weights with a different length raises an error
-    message = "Weights must have same size as csize."
-    with pytest.raises(ValueError, match=message):
-        sampling._set_weights(weights)
 
     message = r"The sum of the weights must be equal to 4\*pi."
     with pytest.raises(ValueError, match=message):

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -39,6 +39,15 @@ def test_setter_n_max():
     assert sampling._n_max == n_max
 
 
+def test_weights_getter():
+    x, y, z = sampling_cube()
+    n_max = 1
+    weights = np.ones(6)*4*np.pi/6
+    sampling = SamplingSphere(x, y, z, n_max, weights=weights)
+
+    np.testing.assert_allclose(sampling.weights, weights)
+
+
 def test_setting_weights():
     x, y, z = sampling_cube()
     n_max = 1

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -59,6 +59,16 @@ def test_setting_weights_invalid():
     with pytest.raises(ValueError, match=message):
         sampling.weights = np.ones(6)/6
 
-    message = r"The sum of the weights must be equal to 4\*pi."
     with pytest.raises(ValueError, match=message):
         sampling._set_weights(np.ones(6)/6)
+
+    message = "All weights must be positive."
+    with pytest.raises(ValueError, match=message):
+        weights_invalid = np.ones(6)*4*np.pi/6
+        weights_invalid[0] = np.nan
+        sampling.weights = weights_invalid
+
+    with pytest.raises(ValueError, match=message):
+        weights_invalid = np.ones(6)*4*np.pi/6 * -1
+        weights_invalid[0] = -1
+        sampling.weights = weights_invalid

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -35,3 +35,40 @@ def test_setter_n_max():
 
     sampling.n_max = n_max
     assert sampling._n_max == n_max
+
+
+def test_setting_weights():
+    x, y, z = sampling_cube()
+    n_max = 1
+    sampling = SamplingSphere(x, y, z, n_max)
+
+    weights = np.ones(6)*4*np.pi/6
+    sampling.weights = weights
+
+    np.testing.assert_array_equal(sampling._weights, weights)
+    assert sampling._weights.shape == (6,)
+
+def test_setting_weights_invalid():
+    x, y, z = sampling_cube()
+    n_max = 1
+    sampling = SamplingSphere(x, y, z, n_max)
+
+    weights = np.ones(5)*4*np.pi/6
+
+    # Check that setting weights with a different length raises an error
+    message = "Weights must have same size as csize."
+    with pytest.raises(ValueError, match=message):
+        sampling.weights = weights
+
+    message = r"The sum of the weights must be equal to 4\*pi."
+    with pytest.raises(ValueError, match=message):
+        sampling.weights = np.ones(6)/6
+
+    # Check that setting weights with a different length raises an error
+    message = "Weights must have same size as csize."
+    with pytest.raises(ValueError, match=message):
+        sampling._set_weights(weights)
+
+    message = r"The sum of the weights must be equal to 4\*pi."
+    with pytest.raises(ValueError, match=message):
+        sampling._set_weights(np.ones(6)/6)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #77 

### Changes proposed in this pull request:

- [x] Add a check if weights used in SamplingSphere sum to the surface integral on the unit-sphere

Weights will be fixed in #120 to avoid conflicts.