### PR TITLE
Upgrade dependencies on develop

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,7 +18,7 @@ pytest-runner
 numpydoc
 pydata-sphinx-theme
 autodocsumm
-pyfar>=0.6.0,<0.8.0
+pyfar>=0.7.3,<0.8.0
 nbsphinx
 nbsphinx-link
 ipykernel

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     'scipy',
     'urllib3',
     'matplotlib>=3.3.0',
-    'pyfar>=0.6.0,<0.8.0',
+    'pyfar>=0.7.3,<0.8.0',
 ]
 
 setup_requirements = [


### PR DESCRIPTION
### Changes proposed in this pull request:

There is a second pull request with identical upgrades for main (#117) because develop and main are currently detached.

- Upgrade to pyfar>=0.7.3. This is required for #120 and #121, which depend on https://github.com/pyfar/pyfar/pull/806
