### PR TITLE
Doc: fix referencing in spherical submod

### DIFF
--- a/spharpy/spherical.py
+++ b/spharpy/spherical.py
@@ -478,15 +478,6 @@ def spherical_harmonic_basis_gradient(n_max, coordinates, normalization="n3d",
     This implementation avoids singularities at the poles using identities
     derived in [#]_ and [#]_.
 
-
-    References
-    ----------
-    .. [#]  E. G. Williams, Fourier Acoustics. Academic Press, 1999.
-    .. [#]  J. Du, C. Chen, V. Lesur, and L. Wang, “Non-singular spherical
-            harmonic expressions of geomagnetic vector and gradient tensor
-            fields in the local north-oriented reference frame,” Geoscientific
-            Model Development, vol. 8, no. 7, pp. 1979-1990, Jul. 2015.
-
     Parameters
     ----------
     n_max : int
@@ -513,6 +504,14 @@ def spherical_harmonic_basis_gradient(n_max, coordinates, normalization="n3d",
         Gradient with regard to the co-latitude angle.
     grad_azimuth : ndarray, complex
         Gradient with regard to the azimuth angle.
+
+    References
+    ----------
+    .. [#]  E. G. Williams, Fourier Acoustics. Academic Press, 1999.
+    .. [#]  J. Du, C. Chen, V. Lesur, and L. Wang, “Non-singular spherical
+            harmonic expressions of geomagnetic vector and gradient tensor
+            fields in the local north-oriented reference frame,” Geoscientific
+            Model Development, vol. 8, no. 7, pp. 1979-1990, Jul. 2015.
 
     Examples
     --------

--- a/spharpy/spherical.py
+++ b/spharpy/spherical.py
@@ -464,7 +464,6 @@ def spherical_harmonic_basis_gradient(n_max, coordinates, normalization="n3d",
     r"""
     Calculates the unit sphere gradients of the complex spherical harmonics.
 
-
     The angular parts of the gradient are defined as
 
     .. math::
@@ -477,7 +476,7 @@ def spherical_harmonic_basis_gradient(n_max, coordinates, normalization="n3d",
 
 
     This implementation avoids singularities at the poles using identities
-    derived in [#]_.
+    derived in [#]_ and [#]_.
 
 
     References
@@ -682,18 +681,6 @@ def spherical_harmonic_basis_gradient_real(n_max, coordinates,
     This implementation avoids singularities at the poles using identities
     derived in [#]_.
 
-
-    References
-    ----------
-    .. [#]  C. Nachbar, F. Zotter, E. Deleflie, and A. Sontacchi, “Ambix - A
-            Suggested Ambisonics Format (revised by F. Zotter),” International
-            Symposium on Ambisonics and Spherical Acoustics,
-            vol. 3, pp. 1-11, 2011.
-    .. [#]  J. Du, C. Chen, V. Lesur, and L. Wang, “Non-singular spherical
-            harmonic expressions of geomagnetic vector and gradient tensor
-            fields in the local north-oriented reference frame,” Geoscientific
-            Model Development, vol. 8, no. 7, pp. 1979-1990, Jul. 2015.
-
     Parameters
     ----------
     n_max : int
@@ -720,6 +707,17 @@ def spherical_harmonic_basis_gradient_real(n_max, coordinates,
         Gradient with respect to the co-latitude angle.
     grad_phi : ndarray, float
         Gradient with respect to the azimuth angle.
+
+    References
+    ----------
+    .. [#]  C. Nachbar, F. Zotter, E. Deleflie, and A. Sontacchi, “Ambix - A
+            Suggested Ambisonics Format (revised by F. Zotter),” International
+            Symposium on Ambisonics and Spherical Acoustics,
+            vol. 3, pp. 1-11, 2011.
+    .. [#]  J. Du, C. Chen, V. Lesur, and L. Wang, “Non-singular spherical
+            harmonic expressions of geomagnetic vector and gradient tensor
+            fields in the local north-oriented reference frame,” Geoscientific
+            Model Development, vol. 8, no. 7, pp. 1979-1990, Jul. 2015.
 
     """  # noqa: E501
     if channel_convention == "fuma" and n_max > 3:


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

contribues to fix all warnings during documentation build

### Changes proposed in this pull request:

- refer missing reference in spharpy.spherical.spherical_harmonic_basis_gradient
- it did not fail before, see #136 
