### PR TITLE
Deprecate scipy Spherical Harmonics function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     'numpy>=1.22',
-    'scipy',
+    'scipy>=1.15',
     'urllib3',
     'matplotlib>=3.10.3',
     'pyfar>=0.7.3,<0.8.0',

--- a/spharpy/samplings/interior.py
+++ b/spharpy/samplings/interior.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy.special as spspecial
-from spharpy.special import spherical_bessel_zeros
+from spharpy.special import spherical_bessel_zeros, spherical_harmonic
 import pyfar as pf
 
 
@@ -123,7 +123,7 @@ def sph_modes_matrix(n_max, k, theta, phi, rad):
     B = np.reshape(B, meshgrid_shape)
     M = np.zeros((*meshgrid_shape, n_coefficients), dtype=complex)
     for m in range(-n_max, n_max+1):
-        Y_m = spspecial.sph_harm(m, n_max, theta.flatten(), phi.flatten())
+        Y_m = spherical_harmonic(n_max, m, phi.flatten(), theta.flatten())
         M[:, :, :, m+n_max] = B * np.reshape(Y_m, meshgrid_shape)
 
     return M

--- a/spharpy/special.py
+++ b/spharpy/special.py
@@ -167,7 +167,7 @@ def spherical_harmonic(n, m, theta, phi):
     m : int
         The spherical harmonic degree
     theta : ndarray, double
-        The elevation angle
+        The colatitude angle
     phi : ndarray, double
         The azimuth angle
 
@@ -179,23 +179,14 @@ def spherical_harmonic(n, m, theta, phi):
     Note
     ----
     This function wraps the spherical harmonic implementation from scipy.
-    The only difference is that we return zeros instead of nan values
-    if n < abs(m).
 
     References
     ----------
     .. [#] B. Rafaely, "Fundamentals of Spherical Array Processing", (2015),
            Springer-Verlag
-
     """
-    theta = np.asarray(theta, dtype=float)
-    phi = np.asarray(phi, dtype=float)
 
-    if n < np.abs(m):
-        sph_harm = np.zeros(theta.shape)
-    else:
-        sph_harm = _spspecial.sph_harm(m, n, phi, theta)
-    return sph_harm
+    return _spspecial.sph_harm_y(n, m, theta, phi)
 
 
 def spherical_harmonic_real(n, m, theta, phi):
@@ -228,7 +219,7 @@ def spherical_harmonic_real(n, m, theta, phi):
     m : int
         The spherical harmonic degree
     theta : ndarray, double
-        The elevation angle
+        The colatitude angle
     phi : ndarray, double
         The azimuth angle
 
@@ -240,7 +231,7 @@ def spherical_harmonic_real(n, m, theta, phi):
     """
     # careful here, scipy uses phi as the elevation angle and
     # theta as the azimuth angle
-    Y_nm_cplx = _spspecial.sph_harm(m, n, phi, theta)
+    Y_nm_cplx = spherical_harmonic(n, m, theta, phi)
 
     if m == 0:
         Y_nm = np.real(Y_nm_cplx)

--- a/tests/test_special.py
+++ b/tests/test_special.py
@@ -107,6 +107,42 @@ class TestHankelPrime(object):
         npt.assert_allclose(res, truth)
 
 
+@pytest.mark.parametrize(['m'], [(-1, ), (0, ), (1, )])
+def test_spherical_harmonic_complex(m):
+    """
+    Test first order complex valued spherical harmonics for selected angels.
+    """
+    # six positions: front, left, back, right, top, bottom
+    pi = np.pi
+    azimuth = np.array([0, pi / 2, pi, 3 * pi / 2, 0, 0])
+    colatitude = np.array([pi / 2, pi / 2, pi / 2, pi / 2, 0, pi])
+
+    # Manually computed desired values according to
+    # Rafaely (2019), Fundamentals of Spherical Array Processing, Table 1.1
+    if m == -1:
+        desired = np.sqrt(3 / (8 * np.pi)) * \
+            np.sin(colatitude) * np.exp(-1j * azimuth)
+    if m == 0:
+        desired = np.sqrt(3 / (4 * np.pi)) * \
+            np.cos(colatitude)
+    if m == 1:
+        desired = -np.sqrt(3 / (8 * np.pi)) * \
+            np.sin(colatitude) * np.exp(1j * azimuth)
+
+    # compute and compare actual values
+    actual = special.spherical_harmonic(1, m, colatitude, azimuth)
+    npt.assert_almost_equal(actual, desired, 10)
+
+
+def test_spherical_harmonic_complex_degree_out_of_range():
+    """Test if zero is returned if the degree m is larger than the order n"""
+    n = 1
+    m = [-2, 2]
+
+    npt.assert_equal(special.spherical_harmonic(n, m, 0, 0),
+                     np.array([0, 0], dtype=complex))
+
+
 def test_spherical_harmonic_derivative_theta():
     n_max = 5
     theta = np.array([np.pi/2, np.pi/2, 0, np.pi/2, np.pi/4])


### PR DESCRIPTION
### Changes proposed in this pull request:

closes #83 

- Use scipy's new `sph_harm_y` instead of `sph_harm` which will be deprecated in scipy 1.17.0
- Restrict scipy to version >= 1.15.0
- Add tests for `spharpy.special.spherical_harmonic` to make sure changes work as intended
- Minor corrections in the docstrings

Notes
- This requires tha latest scipy version. We should discuss if we want this. In my opinon its fine for spharpy 1.0.0.
- This removes 433073 warnings from the tests 😅
