### PR TITLE
restrict scipy version, due to deprecations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     'numpy>=1.22',
-    'scipy',
+    'scipy<1.18.0',
     'urllib3',
     'matplotlib>=3.10.3',
     'pyfar<0.8.0',


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #83

### Changes proposed in this pull request:

- this a fix for the main branch.
- we dont want to force scipy 1.15, so we restict the scipy version before the deprecation happens
-
