### PR TITLE
rename "type" parameters to avoid shadowing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ lint.select = [
     "NPY",    # Check all numpy related deprecations
     "D417",   # Missing argument descriptions in the docstring
     # "PT",     # Pytest style
-    # "A",      # Avoid builtin function and type shadowing
+    "A",      # Avoid builtin function and type shadowing
     # "ERA",    # No commented out code
     "NPY",    # Check all numpy related deprecations
     # "COM",    # trailing comma rules

--- a/spharpy/beamforming/beamforming.py
+++ b/spharpy/beamforming/beamforming.py
@@ -100,7 +100,7 @@ def dolph_chebyshev_weights(
                         (1/2**j)*t_2N[2*j]*P_N[i, n]*x0**(2*j)
         d_n[n] = (2*np.pi/R)*temp
 
-    return sph_identity_matrix(n_max, type='n-nm').T @ d_n
+    return sph_identity_matrix(n_max, matrix_type='n-nm').T @ d_n
 
 
 def rE_max_weights(n_max, normalize=True):

--- a/spharpy/spherical.py
+++ b/spharpy/spherical.py
@@ -1055,14 +1055,14 @@ def sid_to_acn(n_max):
     return np.argsort(linear_sid)
 
 
-def sph_identity_matrix(n_max, type='n-nm'):
+def sph_identity_matrix(n_max, matrix_type='n-nm'):
     """Calculate a spherical harmonic identity matrix.
 
     Parameters
     ----------
     n_max : int
         The spherical harmonic order.
-    type : str, optional
+    matrix_type : str, optional
         The type of identity matrix. Currently only 'n-nm' is implemented.
 
     Returns
@@ -1078,7 +1078,7 @@ def sph_identity_matrix(n_max, type='n-nm'):
     >>> import spharpy
     >>> import matplotlib.pyplot as plt
     >>> n_max = 2
-    >>> E = spharpy.spherical.sph_identity_matrix(n_max, type='n-nm')
+    >>> E = spharpy.spherical.sph_identity_matrix(n_max, matrix_type='n-nm')
     >>> a_n = [1, 2, 3]
     >>> a_nm = E.T @ a_n
     >>> a_nm
@@ -1091,14 +1091,14 @@ def sph_identity_matrix(n_max, type='n-nm'):
         >>> import spharpy
         >>> import matplotlib.pyplot as plt
         >>> n_max = 2
-        >>> E = spharpy.spherical.sph_identity_matrix(n_max, type='n-nm')
+        >>> E = spharpy.spherical.sph_identity_matrix(n_max, matrix_type='n-nm')
         >>> plt.matshow(E, cmap=plt.get_cmap('Greys'))
         >>> plt.gca().set_aspect('equal')
 
-    """
+    """  # noqa: E501
     n_sh = (n_max+1)**2
 
-    if type != 'n-nm':
+    if matrix_type != 'n-nm':
         raise NotImplementedError
 
     identity_matrix = np.zeros((n_max+1, n_sh), dtype=int)

--- a/spharpy/transforms/rotations.py
+++ b/spharpy/transforms/rotations.py
@@ -245,13 +245,13 @@ class RotationSH(Rotation):
             raise ValueError("The order needs to be a positive value.")
         self._n_max = value
 
-    def as_spherical_harmonic(self, type='real'):
+    def as_spherical_harmonic(self, basis_type='real'):
         """Export the rotation operations as a spherical harmonic rotation
         matrices. Supports complex and real-valued spherical harmonics.
 
         Parameters
         ----------
-        real : string, optional
+        basis_type : string, optional
             Spherical harmonic definition. Can either be 'complex' or 'real',
             by default 'real' is used.
 
@@ -264,14 +264,15 @@ class RotationSH(Rotation):
         n_matrices = euler_angles.shape[0]
 
         n_sh = (self.n_max+1)**2
-        if type == 'real':
+        if basis_type == 'real':
             dtype = float
             rot_func = wigner_d_rotation_real
-        elif type == 'complex':
+        elif basis_type == 'complex':
             dtype = complex
             rot_func = wigner_d_rotation
         else:
-            raise ValueError("Invalid spherical harmonic type {}".format(type))
+            raise ValueError(
+                "Invalid spherical harmonic type {}".format(basis_type))
 
         D = np.zeros((n_matrices, n_sh, n_sh), dtype=dtype)
 
@@ -281,7 +282,7 @@ class RotationSH(Rotation):
 
         return np.squeeze(D)
 
-    def apply(self, coefficients, type='real'):
+    def apply(self, coefficients, basis_type='real'):
         """Apply the rotation to L sets of spherical harmonic coefficients.
 
         Parameters
@@ -289,13 +290,16 @@ class RotationSH(Rotation):
         coefficients : array, complex, shape :math:`((n_max+1)^2, L)`
             L sets of spherical harmonic coefficients with a respective order
             :math:`((n_max+1)^2`
+        basis_type : string, optional
+            Spherical harmonic definition. Can either be 'complex' or 'real',
+            by default 'real' is used.
 
         Returns
         -------
         array, complex
             The rotated data
         """
-        D = self.as_spherical_harmonic(type=type)
+        D = self.as_spherical_harmonic(basis_type=basis_type)
         if D.ndim > 2:
             M = np.diag(np.ones((self.n_max+1)**2))
             for d in D:

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -60,7 +60,7 @@ def test_identity_matrix_n_nm():
                           [0, 1, 1, 1, 0, 0, 0, 0, 0],
                           [0, 0, 0, 0, 1, 1, 1, 1, 1]])
 
-    identity = sh.sph_identity_matrix(2, type='n-nm')
+    identity = sh.sph_identity_matrix(2, matrix_type='n-nm')
     np.testing.assert_allclose(reference, identity)
 
 

--- a/tests/test_rotations.py
+++ b/tests/test_rotations.py
@@ -147,7 +147,7 @@ def test_RotationSH():
     with pytest.raises(ValueError):
         rot.n_max = -1
 
-    D_Rot = rot.as_spherical_harmonic(type='real')
+    D_Rot = rot.as_spherical_harmonic(basis_type='real')
 
     reference = np.array([
         [1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -164,17 +164,17 @@ def test_RotationSH():
 
     rot = RotationSH.from_rotvec(n_max, [0, 0, 90], degrees=True)
     np.testing.assert_allclose(
-        rot.as_spherical_harmonic(type='real'),
+        rot.as_spherical_harmonic(basis_type='real'),
         reference, atol=1e-10)
 
     rot = RotationSH.from_euler(n_max, 'zyz', [0, 0, 90], degrees=True)
     np.testing.assert_allclose(
-        rot.as_spherical_harmonic(type='real'),
+        rot.as_spherical_harmonic(basis_type='real'),
         reference, atol=1e-10)
 
     rot = RotationSH.from_quat(n_max, [0, 0, 1/np.sqrt(2), 1/np.sqrt(2)])
     np.testing.assert_allclose(
-        rot.as_spherical_harmonic(type='real'),
+        rot.as_spherical_harmonic(basis_type='real'),
         reference, atol=1e-10)
 
     rot_mat_z_spat = np.array([
@@ -183,7 +183,7 @@ def test_RotationSH():
         [0, 0, 1]])
     rot = RotationSH.from_matrix(n_max, rot_mat_z_spat)
     np.testing.assert_allclose(
-        rot.as_spherical_harmonic(type='real'),
+        rot.as_spherical_harmonic(basis_type='real'),
         reference, atol=1e-7)
 
     # mrp = [0, 0, np.tan(np.pi/2/4)]


### PR DESCRIPTION
Closes #169 
Part of #147 

### Changes proposed in this pull request:

- rename `type` parameters to avoid shadowing (ruff: A)
- in case of the identity-matrix -> `matrix_type`
- when referring to sh-definition -> `basis_type`