### PR TITLE
Class containing the spherical harmonic definition

### DIFF
--- a/spharpy/classes/__init__.py
+++ b/spharpy/classes/__init__.py
@@ -1,6 +1,7 @@
 """spharpy classes."""
 
 from .sh import (
+    SphericalHarmonicDefinition,
     SphericalHarmonics,
 )
 
@@ -13,6 +14,7 @@ from .coordinates import (
 )
 
 __all__ = [
+    'SphericalHarmonicDefinition',
     'SphericalHarmonics',
     'SphericalHarmonicSignal',
     'SamplingSphere',

--- a/spharpy/classes/sh.py
+++ b/spharpy/classes/sh.py
@@ -52,11 +52,7 @@ class SphericalHarmonicDefinition:
                     "condon_shortley must be a bool or the string 'auto'")
             # If basis_type hasn't been set yet, assume "complex" by default,
             # but in practice __init__ sets basis_type before condon_shortley.
-            if self.basis_type == "complex":
-                resolved = True
-            else:
-                resolved = False
-            value = resolved
+            value = self.basis_type == "complex"
         elif not isinstance(value, bool):
             raise TypeError(
                 "condon_shortley must be a bool or the string 'auto'")

--- a/spharpy/classes/sh.py
+++ b/spharpy/classes/sh.py
@@ -91,9 +91,6 @@ class SphericalHarmonicDefinition:
             raise ValueError("Invalid channel convention, "
                              "currently only 'acn' "
                              "and 'fuma' are supported")
-        if value == "fuma" and self.n_max > 3:
-            raise ValueError("n_max > 3 is not allowed with 'fuma' " \
-                            "channel convention")
         self._channel_convention = value
 
     @property
@@ -109,9 +106,6 @@ class SphericalHarmonicDefinition:
                 "Invalid normalization, "
                 "currently only 'n3d', 'maxN', 'sn3d' are "
                 "supported")
-        if value == "maxN" and self.n_max > 3:
-            raise ValueError("n_max > 3 is not allowed with " \
-                            "'maxN' normalization")
         self._normalization = value
 
 
@@ -358,6 +352,10 @@ class SphericalHarmonics(SphericalHarmonicDefinition):
     @SphericalHarmonicDefinition.channel_convention.setter
     def channel_convention(self, value):
         """Get or set the channel order convention."""
+        if value == "fuma" and self.n_max > 3:
+            raise ValueError("n_max > 3 is not allowed with 'fuma' " \
+                            "channel convention")
+
         super(__class__, SphericalHarmonics).channel_convention.fset(
             self, value)
         if value != self._channel_convention:
@@ -366,6 +364,10 @@ class SphericalHarmonics(SphericalHarmonicDefinition):
     @SphericalHarmonicDefinition.normalization.setter
     def normalization(self, value):
         """Get or set the normalization convention."""
+        if value == "maxN" and self.n_max > 3:
+            raise ValueError(
+                "n_max > 3 is not allowed with 'maxN' normalization")
+
         super(__class__, SphericalHarmonics).normalization.fset(self, value)
         if value != self._normalization:
             self._reset_compute_attributes()

--- a/spharpy/classes/sh.py
+++ b/spharpy/classes/sh.py
@@ -28,6 +28,11 @@ class SphericalHarmonicDefinition:
             normalization="n3d",
             condon_shortley="auto",
         ):
+        self._basis_type = None
+        self._channel_convention = None
+        self._condon_shortley = None
+        self._normalization = None
+
         self.condon_shortley = condon_shortley
         self.basis_type = basis_type
         self.channel_convention = channel_convention

--- a/spharpy/classes/sh.py
+++ b/spharpy/classes/sh.py
@@ -6,6 +6,117 @@ import pyfar as pf
 import spharpy as sy
 
 
+class SphericalHarmonicDefinition:
+    """Class storing the definition of spherical harmonics.
+
+    Attributes
+    ----------
+    condon_shortley : bool
+        Condon-Shortley phase term.
+    basis_type : str
+        Type of spherical harmonic basis, either 'real' or 'complex'.
+    channel_convention : str
+        Channel ordering convention, either 'acn' or 'fuma'.
+    normalization : str
+        Normalization convention, either 'n3d', 'maxN', or 'sn3d'.
+    """
+
+    def __init__(
+            self,
+            basis_type="real",
+            channel_convention="acn",
+            normalization="n3d",
+            condon_shortley="auto",
+        ):
+        self.condon_shortley = condon_shortley
+        self.basis_type = basis_type
+        self.channel_convention = channel_convention
+        self.normalization = normalization
+
+    @property
+    def condon_shortley(self):
+        """Get or set the Condon-Shortley phase term."""
+        return self._condon_shortley
+
+    @condon_shortley.setter
+    def condon_shortley(self, value):
+        """Get or set the Condon-Shortley phase term."""
+        if isinstance(value, str):
+            if value != 'auto':
+                raise ValueError(
+                    "condon_shortley must be a bool or the string 'auto'")
+            # If basis_type hasn't been set yet, assume "complex" by default,
+            # but in practice __init__ sets basis_type before condon_shortley.
+            if self.basis_type == "complex":
+                resolved = True
+            else:
+                resolved = False
+            value = resolved
+        elif not isinstance(value, bool):
+            raise TypeError(
+                "condon_shortley must be a bool or the string 'auto'")
+        if value != self._condon_shortley:
+            self._reset_compute_attributes()
+        self._condon_shortley = value
+
+    @property
+    def basis_type(self):
+        """The type of spherical harmonic basis. Can be ``'complex'`` or
+        ``'real'``.
+        """
+        return self._basis_type
+
+    @basis_type.setter
+    def basis_type(self, value):
+        """The type of spherical harmonic basis. Can be ``'complex'`` or
+        ``'real'``.
+        """
+        if value not in ["complex", "real"]:
+            raise ValueError("Invalid basis type, only "
+                             "'complex' and 'real' are supported")
+        if value != self._basis_type:
+            self._basis_type = value
+
+    @property
+    def channel_convention(self):
+        """Get or set the channel ordering convention."""
+        return self._channel_convention
+
+    @channel_convention.setter
+    def channel_convention(self, value):
+        """Get or set the channel order convention."""
+        if value not in ["acn", "fuma"]:
+            raise ValueError("Invalid channel convention, "
+                             "currently only 'acn' "
+                             "and 'fuma' are supported")
+        if value == "fuma" and self.n_max > 3:
+            raise ValueError("n_max > 3 is not allowed with 'fuma' " \
+                            "channel convention")
+        if value != self._channel_convention:
+            self._reset_compute_attributes()
+            self._channel_convention = value
+
+    @property
+    def normalization(self):
+        """Get or set the normalization convention."""
+        return self._normalization
+
+    @normalization.setter
+    def normalization(self, value):
+        """Get or set the normalization convention."""
+        if value not in ["n3d", "maxN", "sn3d"]:
+            raise ValueError(
+                "Invalid normalization, "
+                "currently only 'n3d', 'maxN', 'sn3d' are "
+                "supported")
+        if value == "maxN" and self.n_max > 3:
+            raise ValueError("n_max > 3 is not allowed with " \
+                            "'maxN' normalization")
+        if value != self._normalization:
+            self._reset_compute_attributes()
+            self._normalization = value
+
+
 class SphericalHarmonics:
     r"""
     Compute spherical harmonic basis matrices, their inverses, and gradients.

--- a/spharpy/classes/sh.py
+++ b/spharpy/classes/sh.py
@@ -33,8 +33,10 @@ class SphericalHarmonicDefinition:
         self._condon_shortley = None
         self._normalization = None
 
-        self.condon_shortley = condon_shortley
+        # basis_type needs to be initialized first, since the default for the
+        # Condon-Shortley phase depends on the basis type
         self.basis_type = basis_type
+        self.condon_shortley = condon_shortley
         self.channel_convention = channel_convention
         self.normalization = normalization
 

--- a/spharpy/classes/sh.py
+++ b/spharpy/classes/sh.py
@@ -52,26 +52,21 @@ class SphericalHarmonicDefinition:
             if value != 'auto':
                 raise ValueError(
                     "condon_shortley must be a bool or the string 'auto'")
-            # If basis_type hasn't been set yet, assume "complex" by default,
-            # but in practice __init__ sets basis_type before condon_shortley.
+
             value = self.basis_type == "complex"
         elif not isinstance(value, bool):
-            raise TypeError(
+            raise ValueError(
                 "condon_shortley must be a bool or the string 'auto'")
         self._condon_shortley = value
 
     @property
     def basis_type(self):
-        """The type of spherical harmonic basis. Can be ``'complex'`` or
-        ``'real'``.
-        """
+        """Get or set the type of spherical harmonic basis."""
         return self._basis_type
 
     @basis_type.setter
     def basis_type(self, value):
-        """The type of spherical harmonic basis. Can be ``'complex'`` or
-        ``'real'``.
-        """
+        """Get or set the type of spherical harmonic basis."""
         if value not in ["complex", "real"]:
             raise ValueError("Invalid basis type, only "
                              "'complex' and 'real' are supported")

--- a/spharpy/classes/sh.py
+++ b/spharpy/classes/sh.py
@@ -55,8 +55,6 @@ class SphericalHarmonicDefinition:
         elif not isinstance(value, bool):
             raise TypeError(
                 "condon_shortley must be a bool or the string 'auto'")
-        if value != self._condon_shortley:
-            self._reset_compute_attributes()
         self._condon_shortley = value
 
     @property
@@ -74,8 +72,7 @@ class SphericalHarmonicDefinition:
         if value not in ["complex", "real"]:
             raise ValueError("Invalid basis type, only "
                              "'complex' and 'real' are supported")
-        if value != self._basis_type:
-            self._basis_type = value
+        self._basis_type = value
 
     @property
     def channel_convention(self):
@@ -92,9 +89,7 @@ class SphericalHarmonicDefinition:
         if value == "fuma" and self.n_max > 3:
             raise ValueError("n_max > 3 is not allowed with 'fuma' " \
                             "channel convention")
-        if value != self._channel_convention:
-            self._reset_compute_attributes()
-            self._channel_convention = value
+        self._channel_convention = value
 
     @property
     def normalization(self):
@@ -112,12 +107,10 @@ class SphericalHarmonicDefinition:
         if value == "maxN" and self.n_max > 3:
             raise ValueError("n_max > 3 is not allowed with " \
                             "'maxN' normalization")
-        if value != self._normalization:
-            self._reset_compute_attributes()
-            self._normalization = value
+        self._normalization = value
 
 
-class SphericalHarmonics:
+class SphericalHarmonics(SphericalHarmonicDefinition):
     r"""
     Compute spherical harmonic basis matrices, their inverses, and gradients.
 
@@ -267,31 +260,13 @@ class SphericalHarmonics:
         self.condon_shortley = condon_shortley
 
     # Properties
-    @property
-    def condon_shortley(self):
-        """Get or set the Condon-Shortley phase term."""
-        return self._condon_shortley
 
-    @condon_shortley.setter
+    @SphericalHarmonicDefinition.condon_shortley.setter
     def condon_shortley(self, value):
         """Get or set the Condon-Shortley phase term."""
-        if isinstance(value, str):
-            if value != 'auto':
-                raise ValueError(
-                    "condon_shortley must be a bool or the string 'auto'")
-            # If basis_type hasn't been set yet, assume "complex" by default,
-            # but in practice __init__ sets basis_type before condon_shortley.
-            if self.basis_type == "complex":
-                resolved = True
-            else:
-                resolved = False
-            value = resolved
-        elif not isinstance(value, bool):
-            raise TypeError(
-                "condon_shortley must be a bool or the string 'auto'")
+        super(__class__, SphericalHarmonics).condon_shortley.fset(self, value)
         if value != self._condon_shortley:
             self._reset_compute_attributes()
-        self._condon_shortley = value
 
     @property
     def n_max(self):
@@ -334,20 +309,12 @@ class SphericalHarmonics:
             self._reset_compute_attributes()
             self._coordinates = value
 
-    @property
-    def basis_type(self):
-        """Get or set the type of spherical harmonic basis."""
-        return self._basis_type
-
-    @basis_type.setter
+    @SphericalHarmonicDefinition.basis_type.setter
     def basis_type(self, value):
         """Get or set the type of spherical harmonic basis."""
-        if value not in ["complex", "real"]:
-            raise ValueError("Invalid basis type, only "
-                             "'complex' and 'real' are supported")
+        super(__class__, SphericalHarmonics).basis_type.fset(self, value)
         if value != self._basis_type:
             self._reset_compute_attributes()
-            self._basis_type = value
 
     @property
     def inverse_method(self):
@@ -383,44 +350,20 @@ class SphericalHarmonics:
             self._reset_compute_attributes()
             self._inverse_method = value
 
-    @property
-    def channel_convention(self):
-        """Get or set the channel ordering convention."""
-        return self._channel_convention
-
-    @channel_convention.setter
+    @SphericalHarmonicDefinition.channel_convention.setter
     def channel_convention(self, value):
         """Get or set the channel order convention."""
-        if value not in ["acn", "fuma"]:
-            raise ValueError("Invalid channel convention, "
-                             "currently only 'acn' "
-                             "and 'fuma' are supported")
-        if value == "fuma" and self.n_max > 3:
-            raise ValueError("n_max > 3 is not allowed with 'fuma' " \
-                            "channel convention")
+        super(__class__, SphericalHarmonics).channel_convention.fset(
+            self, value)
         if value != self._channel_convention:
             self._reset_compute_attributes()
-            self._channel_convention = value
 
-    @property
-    def normalization(self):
-        """Get or set the normalization convention."""
-        return self._normalization
-
-    @normalization.setter
+    @SphericalHarmonicDefinition.normalization.setter
     def normalization(self, value):
         """Get or set the normalization convention."""
-        if value not in ["n3d", "maxN", "sn3d"]:
-            raise ValueError(
-                "Invalid normalization, "
-                "currently only 'n3d', 'maxN', 'sn3d' are "
-                "supported")
-        if value == "maxN" and self.n_max > 3:
-            raise ValueError("n_max > 3 is not allowed with " \
-                            "'maxN' normalization")
+        super(__class__, SphericalHarmonics).normalization.fset(self, value)
         if value != self._normalization:
             self._reset_compute_attributes()
-            self._normalization = value
 
     @property
     def basis(self):

--- a/tests/test_sh_class.py
+++ b/tests/test_sh_class.py
@@ -16,6 +16,7 @@ def test_spherical_harmonics_definition_init():
     assert definition.basis_type == 'real'
     assert definition.normalization == 'n3d'
     assert definition.channel_convention == 'acn'
+    assert definition.condon_shortley is False
 
 
 @pytest.mark.parametrize("phase_convention", [True, False])
@@ -50,8 +51,11 @@ def test_setter_phase_convention_auto():
 
 def test_setter_phase_convention_invalid():
     sph_harm = SphericalHarmonicDefinition()
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError, match='must be a bool or the string'):
         sph_harm.condon_shortley = 123  # Invalid type
+
+    with pytest.raises(ValueError, match='must be a bool or the string'):
+        sph_harm.condon_shortley = "invalid"  # Invalid string
 
 
 @pytest.mark.parametrize("channel_convention", ["acn", "fuma"])
@@ -87,6 +91,18 @@ def test_init_normalization_definition(normalization):
     sph_harm = SphericalHarmonicDefinition(
         normalization=normalization)
     assert sph_harm.normalization == normalization
+
+
+def test_setter_basis_type():
+    sph_harm = SphericalHarmonicDefinition()
+    sph_harm.basis_type = "complex"
+    assert sph_harm.basis_type == "complex"
+
+    sph_harm.basis_type = "real"
+    assert sph_harm.basis_type == "real"
+
+    with pytest.raises(ValueError, match='Invalid basis type'):
+        sph_harm.basis_type = "invalid"  # Invalid value
 
 
 def test_setter_normalization_definition_invalid():

--- a/tests/test_sh_class.py
+++ b/tests/test_sh_class.py
@@ -118,7 +118,6 @@ def test_sphharm_init():
     assert sph_harm.n_max == 2
     assert np.all(sph_harm.coordinates == coordinates)
     assert sph_harm.inverse_method == 'quadrature'
-    assert not sph_harm.condon_shortley
 
 def test_sphharm_init_invalid_coordinates():
     with pytest.raises(TypeError,

--- a/tests/test_sh_class.py
+++ b/tests/test_sh_class.py
@@ -18,29 +18,79 @@ def test_spherical_harmonics_definition_init():
     assert definition.channel_convention == 'acn'
 
 
-def test_setter_phase_convention():
+@pytest.mark.parametrize("phase_convention", [True, False])
+def test_setter_phase_convention(phase_convention):
     sph_harm = SphericalHarmonicDefinition()
-    sph_harm.condon_shortley = "auto"
-    assert not sph_harm.condon_shortley
+    sph_harm.condon_shortley = phase_convention
+    assert sph_harm.condon_shortley == phase_convention
 
+
+def test_init_phase_convention_auto():
+    sph_harm = SphericalHarmonicDefinition(
+        basis_type="complex",
+        condon_shortley="auto")
+    assert sph_harm.condon_shortley is True
+
+    sph_harm = SphericalHarmonicDefinition(
+        basis_type="real",
+        condon_shortley="auto")
+    assert sph_harm.condon_shortley is False
+
+def test_setter_phase_convention_auto():
+    sph_harm = SphericalHarmonicDefinition()
+    sph_harm.basis_type = "complex"
+    sph_harm.condon_shortley = "auto"
+    assert sph_harm.condon_shortley is True
+
+    sph_harm = SphericalHarmonicDefinition()
+    sph_harm.basis_type = "real"
+    sph_harm.condon_shortley = "auto"
+    assert sph_harm.condon_shortley is False
+
+
+def test_setter_phase_convention_invalid():
+    sph_harm = SphericalHarmonicDefinition()
     with pytest.raises(TypeError):
         sph_harm.condon_shortley = 123  # Invalid type
 
 
-def test_setter_channel_convention_definition():
-    sph_harm = SphericalHarmonicDefinition(channel_convention='acn')
-    sph_harm.channel_convention = "fuma"
-    assert sph_harm.channel_convention == "fuma"
+@pytest.mark.parametrize("channel_convention", ["acn", "fuma"])
+def test_setter_channel_convention_definition(channel_convention):
+    sph_harm = SphericalHarmonicDefinition()
+    sph_harm.channel_convention = channel_convention
+    assert sph_harm.channel_convention == channel_convention
 
+
+@pytest.mark.parametrize("channel_convention", ["acn", "fuma"])
+def test_init_channel_convention_definition(channel_convention):
+    sph_harm = SphericalHarmonicDefinition(
+        channel_convention=channel_convention)
+    assert sph_harm.channel_convention == channel_convention
+
+
+
+def test_setter_channel_convention_definition_invalid():
+    sph_harm = SphericalHarmonicDefinition()
     with pytest.raises(ValueError, match='Invalid channel convention'):
         sph_harm.channel_convention = "invalid"  # Invalid value
 
 
-def test_setter_normalization_definition():
-    sph_harm = SphericalHarmonicDefinition(normalization='n3d')
-    sph_harm.normalization = "sn3d"
-    assert sph_harm.normalization == "sn3d"
+@pytest.mark.parametrize("normalization", ["n3d", "sn3d", "maxN"])
+def test_setter_normalization_definition(normalization):
+    sph_harm = SphericalHarmonicDefinition()
+    sph_harm.normalization = normalization
+    assert sph_harm.normalization == normalization
 
+
+@pytest.mark.parametrize("normalization", ["n3d", "sn3d", "maxN"])
+def test_init_normalization_definition(normalization):
+    sph_harm = SphericalHarmonicDefinition(
+        normalization=normalization)
+    assert sph_harm.normalization == normalization
+
+
+def test_setter_normalization_definition_invalid():
+    sph_harm = SphericalHarmonicDefinition()
     with pytest.raises(ValueError, match='Invalid normalization'):
         sph_harm.normalization = "invalid"  # Invalid value
 

--- a/tests/test_sh_class.py
+++ b/tests/test_sh_class.py
@@ -6,6 +6,44 @@ import numpy as np
 import pyfar as pf
 from spharpy import SphericalHarmonics
 from spharpy.samplings import gaussian, calculate_sampling_weights, equiangular
+from spharpy.classes.sh import SphericalHarmonicDefinition
+
+
+def test_spherical_harmonics_definition_init():
+    """Test default behavior.
+    """
+    definition = SphericalHarmonicDefinition()
+    assert definition.basis_type == 'real'
+    assert definition.normalization == 'n3d'
+    assert definition.channel_convention == 'acn'
+
+
+def test_setter_phase_convention():
+    sph_harm = SphericalHarmonicDefinition()
+    sph_harm.condon_shortley = "auto"
+    assert not sph_harm.condon_shortley
+
+    with pytest.raises(TypeError):
+        sph_harm.condon_shortley = 123  # Invalid type
+
+
+def test_setter_channel_convention_definition():
+    sph_harm = SphericalHarmonicDefinition(channel_convention='acn')
+    sph_harm.channel_convention = "fuma"
+    assert sph_harm.channel_convention == "fuma"
+
+    with pytest.raises(ValueError, match='Invalid channel convention'):
+        sph_harm.channel_convention = "invalid"  # Invalid value
+
+
+def test_setter_normalization_definition():
+    sph_harm = SphericalHarmonicDefinition(normalization='n3d')
+    sph_harm.normalization = "sn3d"
+    assert sph_harm.normalization == "sn3d"
+
+    with pytest.raises(ValueError, match='Invalid normalization'):
+        sph_harm.normalization = "invalid"  # Invalid value
+
 
 def test_sphharm_init():
     """Test default behaviour after initialization."""
@@ -13,9 +51,6 @@ def test_sphharm_init():
     sph_harm = SphericalHarmonics(n_max=2, coordinates=coordinates)
     assert sph_harm.n_max == 2
     assert np.all(sph_harm.coordinates == coordinates)
-    assert sph_harm.basis_type == 'real'
-    assert sph_harm.normalization == 'n3d'
-    assert sph_harm.channel_convention == 'acn'
     assert sph_harm.inverse_method == 'quadrature'
     assert not sph_harm.condon_shortley
 
@@ -93,23 +128,10 @@ def test_setter_n_max():
         # set maxN normalization
         sph_harm.normalization = "maxN"  # Invalid with n_max > 3
 
-def test_setter_phase_convention():
-    coordinates = equiangular(n_points=4)
-    sph_harm = SphericalHarmonics(n_max=2, coordinates=coordinates)
-    sph_harm.condon_shortley = "auto"
-    assert not sph_harm.condon_shortley
-
-    with pytest.raises(TypeError):
-        sph_harm.condon_shortley = 123  # Invalid type
 
 def test_setter_channel_convention():
     coordinates = equiangular(n_points=4)
     sph_harm = SphericalHarmonics(n_max=2, coordinates=coordinates)
-    sph_harm.channel_convention = "fuma"
-    assert sph_harm.channel_convention == "fuma"
-
-    with pytest.raises(ValueError, match='Invalid channel convention'):
-        sph_harm.channel_convention = "invalid"  # Invalid value
 
     sph_harm.channel_convention = "fuma"  # Invalid with n_max > 3
     with pytest.raises(ValueError, match='n_max > 3 is not allowed with'):
@@ -117,14 +139,8 @@ def test_setter_channel_convention():
 
 def test_setter_normalization():
     coordinates = equiangular(n_points=4)
-    sph_harm = SphericalHarmonics(n_max=2, coordinates=coordinates)
-    sph_harm.normalization = "sn3d"
-    assert sph_harm.normalization == "sn3d"
+    sph_harm = SphericalHarmonics(n_max=4, coordinates=coordinates)
 
-    with pytest.raises(ValueError, match='Invalid normalization'):
-        sph_harm.normalization = "invalid"  # Invalid value
-
-    sph_harm.n_max = 4
     with pytest.raises(ValueError, match='n_max > 3 is not allowed with'):
         sph_harm.normalization = "maxN"  # Invalid with n_max > 3
 


### PR DESCRIPTION
This additional class could be used to provide the definition of the sperical harmonics to other classes.
The new class already serves as base class for the `SphericalHarmonics` class.

Requires #172 

Todo:

- [ ] Update to new monopole normalizations
- [ ] Add order (optional)
