### PR TITLE
Replace pcolormesh with contourf in sph.plot.contour_map

### DIFF
--- a/spharpy/plot/spatial.py
+++ b/spharpy/plot/spatial.py
@@ -843,8 +843,8 @@ def contour_map(
 
     ax.contour(xi, yi, zi, levels=levels, linewidths=0.5, colors='k',
                vmin=limits[0], vmax=limits[1], extend=extend)
-    cf = ax.pcolormesh(xi, yi, zi, cmap=cmap, shading='gouraud',
-                       vmin=limits[0], vmax=limits[1])
+    cf = ax.contourf(xi, yi, zi, cmap=cmap, shading='gouraud',
+                     vmin=limits[0], vmax=limits[1])
 
     plt.grid(True)
     if colorbar:


### PR DESCRIPTION
**Replace matplotlib `pcolormesh` with `contourf` in `sph.plot.contour_map`.**

Due to a bug in Matplotlib, `contour` and `contourf` were not working properly. Since this bug has now been fixed, it is more appropriate to use `contourf` instead of `pcolormesh` for filled contour plots.

Related issue: #91
