### PR TITLE
Constrain scipy version to be below 1.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     'numpy>=1.22',
-    'scipy',
+    'scipy<1.17.0',
     'urllib3',
     'matplotlib>=3.10.3',
     'pyfar<0.8.0',


### PR DESCRIPTION
Required due to deprecations of special functions.

Workaround for #83 
