### PR TITLE
Phase twilight docstring not escaped math symbols

### DIFF
--- a/spharpy/plot/cmap.py
+++ b/spharpy/plot/cmap.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 def phase_twilight(lut=512):
-    """
+    r"""
     Cyclic color map for displaying phase information.
 
     This is a modified version of the twilight color map from matplotlib.

--- a/spharpy/plot/cmap.py
+++ b/spharpy/plot/cmap.py
@@ -10,7 +10,7 @@ def phase_twilight(lut=512):
 
     This is a modified version of the twilight color map from matplotlib.
     The colormap is rotated such that :math:`0` is encoded as red hues, while
-    `:math:\pi` is encoded as blue hues.
+    :math:`\pi` is encoded as blue hues.
 
     Parameters
     ----------

--- a/spharpy/plot/cmap.py
+++ b/spharpy/plot/cmap.py
@@ -9,7 +9,7 @@ def phase_twilight(lut=512):
     Cyclic color map for displaying phase information.
 
     This is a modified version of the twilight color map from matplotlib.
-    The colormap is rotated such that `:math:0` is encoded as red hues, while
+    The colormap is rotated such that :math:`0` is encoded as red hues, while
     `:math:\pi` is encoded as blue hues.
 
     Parameters


### PR DESCRIPTION
### Changes proposed in this pull request:

- Converted to raw docstring