### PR TITLE
fixes information in cube equidistant docsting

### DIFF
--- a/spharpy/samplings/samplings.py
+++ b/spharpy/samplings/samplings.py
@@ -19,7 +19,8 @@ def cube_equidistant(n_points):
     """
     Create a cuboid sampling with equidistant spacings in x, y, and z.
 
-    The cube will have dimensions 1 x 1 x 1.
+    The cube spans from -1 to 1 along each axis (size 2 x 2 x 2).
+    The cube is centered at the origin.
 
     Parameters
     ----------


### PR DESCRIPTION
### Changes proposed in this pull request:

- [samplings.cube_equidistant](https://spharpy--190.org.readthedocs.build/en/190/modules/spharpy.samplings.html#spharpy.samplings.cube_equidistant) docstring was not correct. 
- the size of the cube is 2x2x2 and not 1x1x1
-
