### PR TITLE
Docs/remove 'apply' documentation in calculate_sampling_weights

### DIFF
--- a/spharpy/samplings/helpers.py
+++ b/spharpy/samplings/helpers.py
@@ -90,8 +90,6 @@ def calculate_sampling_weights(sampling, round_decimals=12):
         Decimal precision used for ``sampling.radius``. All radii must be
         identical to compute the sampling weights. This can be used to ignore
         numerical noise on the radii. The default is ``12``.
-    apply : boolean, optional
-        Whether or not to store the weights into the class object
 
     Returns
     -------


### PR DESCRIPTION
The _apply_ parameter in `calculate_sampling_weights()` doesn't exist anymore. 