### PR TITLE
Refactor/cased channel convention

### DIFF
--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -11,7 +11,7 @@ class SphericalHarmonicSignal(Signal):
 
     Objects of this class contain spherical harmonics coefficients which are
     directly convertible between time and frequency domain (equally spaced
-    samples and frequency bins), the channel conventions ACN and FUMA, as
+    samples and frequency bins), the channel conventions ACN and FuMa, as
     well as the normalizations N3D, SN3D, or MaxN, see [#]_. The definition of
     the spherical harmonics basis functions is based on the scipy convention
     which includes the Condon-Shortley phase, [#]_, [#]_.
@@ -39,7 +39,7 @@ class SphericalHarmonicSignal(Signal):
         ``'maxN'``, ``'SN3D'``, or ``'SNM'``.
         (maxN is only supported up to 3rd order)
     channel_convention : str
-        Channel ordering convention, either ``'acn'`` or ``'fuma'``.
+        Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
         (FuMa is only supported up to 3rd order)
     condon_shortley : bool
         Flag to indicate if the Condon-Shortley phase term is included
@@ -116,9 +116,9 @@ class SphericalHarmonicSignal(Signal):
         self._normalization = normalization
 
         # set channel_convention
-        if channel_convention not in ["acn", "fuma"]:
-            raise ValueError("Invalid channel convention, has to be 'acn' "
-                             f"or 'fuma', but is {channel_convention}")
+        if channel_convention not in ["ACN", "FuMa"]:
+            raise ValueError("Invalid channel convention, has to be 'ACN' "
+                             f"or 'FuMa', but is {channel_convention}")
         self._channel_convention = channel_convention
 
         # set Condon Shortley

--- a/spharpy/classes/sh.py
+++ b/spharpy/classes/sh.py
@@ -17,8 +17,8 @@ class SphericalHarmonicDefinition:
         Type of spherical harmonic basis, either ``'real'`` or ``'complex'``.
         The default is ``'real'``.
     channel_convention : str, optional
-        Channel ordering convention, either ``'acn'`` or ``'fuma'``.
-        The default is ``'acn'``. Note that ``'fuma'`` is only supported up to
+        Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
+        The default is ``'ACN'``. Note that ``'FuMa'`` is only supported up to
         3rd order.
     normalization : str, optional
         Normalization convention, either ``'N3D'``, ``'NM'``, ``'maxN'``,
@@ -35,7 +35,7 @@ class SphericalHarmonicDefinition:
             self,
             n_max=0,
             basis_type="real",
-            channel_convention="acn",
+            channel_convention="ACN",
             normalization="N3D",
             condon_shortley="auto",
         ):
@@ -65,9 +65,9 @@ class SphericalHarmonicDefinition:
         """Get or set the spherical harmonic order."""
         if value < 0 or value % 1 != 0:
             raise ValueError("n_max must be a positive integer")
-        if self.channel_convention == "fuma" and value > 3:
+        if self.channel_convention == "FuMa" and value > 3:
             raise ValueError(
-                "n_max > 3 is not allowed with 'fuma' channel convention")
+                "n_max > 3 is not allowed with 'FuMa' channel convention")
         if self.normalization == "maxN" and value > 3:
             raise ValueError(
                 "n_max > 3 is not allowed with 'maxN' normalization")
@@ -122,14 +122,14 @@ class SphericalHarmonicDefinition:
     @channel_convention.setter
     def channel_convention(self, value):
         """Get or set the channel order convention."""
-        if value not in ["acn", "fuma"]:
+        if value not in ["ACN", "FuMa"]:
             raise ValueError("Invalid channel convention, "
-                             "currently only 'acn' "
-                             "and 'fuma' are supported")
+                             "currently only 'ACN' "
+                             "and 'FuMa' are supported")
 
-        if value == "fuma" and self.n_max > 3:
+        if value == "FuMa" and self.n_max > 3:
             raise ValueError(
-                "n_max > 3 is not allowed with 'fuma' channel convention")
+                "n_max > 3 is not allowed with 'FuMa' channel convention")
 
         if self._channel_convention != value:
             self._channel_convention = value
@@ -243,8 +243,8 @@ class SphericalHarmonics(SphericalHarmonicDefinition):
 
     - channel_convention: Defines the channel ordering convention.
 
-        - ``'acn'``: Follows the Ambisonic Channel Number (ACN) convention.
-        - ``'fuma'``: Follows the Furse-Malham (FuMa) convention.
+        - ``'ACN'``: Follows the Ambisonic Channel Number (ACN) convention.
+        - ``'FuMa'``: Follows the Furse-Malham (FuMa) convention.
         (FuMa is only supported up to 3rd order)
 
     - inverse_method: Defines the type of inverse transform.
@@ -274,8 +274,8 @@ class SphericalHarmonics(SphericalHarmonicDefinition):
         The default is ``'N3D'``.
         (maxN is only supported up to 3rd order)
     channel_convention : str, optional
-        Channel ordering convention, either ``'acn'`` or ``'fuma'``.
-        The default is ``'acn'``.
+        Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
+        The default is ``'ACN'``.
         (FuMa is only supported up to 3rd order)
     inverse_method : {'auto', 'quadrature', 'pseudo_inverse'}, default='auto'
         Method for computing the inverse transform:
@@ -298,7 +298,7 @@ class SphericalHarmonics(SphericalHarmonicDefinition):
         coordinates,
         basis_type="real",
         normalization="N3D",
-        channel_convention="acn",
+        channel_convention="ACN",
         inverse_method="auto",
         condon_shortley="auto",
     ):

--- a/spharpy/spherical.py
+++ b/spharpy/spherical.py
@@ -13,9 +13,9 @@ def acn_to_nm(acn):
 
     .. math::
 
-        n = \lfloor \sqrt{\mathrm{acn} + 1} \rfloor - 1
+        n = \lfloor \sqrt{\mathrm{ACN} + 1} \rfloor - 1
 
-        m = \mathrm{acn} - n^2 -n
+        m = \mathrm{ACN} - n^2 -n
 
     Parameters
     ----------
@@ -51,11 +51,12 @@ def nm_to_acn(n, m):
     r"""
     Calculate the linear index coefficient for a order n and degree m.
 
-    The linear index corresponds to the Ambisonics Channel Convention [#]_.
+    The linear index corresponds to the Ambisonics Channel Convention (ACN)
+    [#]_.
 
     .. math::
 
-        \mathrm{acn} = n^2 + n + m
+        \mathrm{ACN} = n^2 + n + m
 
     References
     ----------
@@ -259,7 +260,7 @@ def renormalize(data, channel_convention, current_norm, target_norm, axis):
         coefficients or basis functions.
     channel_convention : str
         Channel convention of the data which should be renormalized. Valid
-        conventions are `"acn"` or `"fuma"`.
+        conventions are `"ACN"` or `"FuMa"`.
     current_norm : str
         Current normalization. Valid normalizations are `"N3D"`, `"NM"`,
         `"maxN"`, `"SN3D"`, or `"SNM"`.
@@ -282,9 +283,9 @@ def renormalize(data, channel_convention, current_norm, target_norm, axis):
         raise ValueError("Invalid number of SH channels: "
                          f"{data.shape[-2]}. It must match (n_max + 1)^2.")
 
-    if channel_convention not in ["acn", "fuma"]:
-        raise ValueError("Invalid channel convention. Has to be 'acn' "
-                         f"or 'fuma', but is {channel_convention}")
+    if channel_convention not in ["ACN", "FuMa"]:
+        raise ValueError("Invalid channel convention. Has to be 'ACN' "
+                         f"or 'FuMa', but is {channel_convention}")
 
     if current_norm not in ["N3D", "NM", "maxN", "SN3D", "SNM"]:
         raise ValueError("Invalid current normalization. Has to be 'N3D', "
@@ -300,7 +301,7 @@ def renormalize(data, channel_convention, current_norm, target_norm, axis):
 
     acn = np.arange(data.shape[axis])
 
-    if channel_convention == "fuma":
+    if channel_convention == "FuMa":
         orders, _ = fuma_to_nm(acn)
     else:
         orders, _ = acn_to_nm(acn)
@@ -348,9 +349,9 @@ def change_channel_convention(data, current, target, axis):
         Data of which channel convention should be changed. Either spherical
         harmonics coefficients or bases functions.
     current : str
-        Current channel convention. Valid conventions are `"acn"` or `"fuma"`.
+        Current channel convention. Valid conventions are `"ACN"` or `"FuMa"`.
     target : str
-        Desired channel convention. Valid conventions are `"acn"` or `"fuma"`.
+        Desired channel convention. Valid conventions are `"ACN"` or `"FuMa"`.
     axis : integer
         Axis along which the channel convention should be changed
 
@@ -359,19 +360,19 @@ def change_channel_convention(data, current, target, axis):
     data : ndarray
         Data with changed channel convention
     """
-    if current not in ["acn", "fuma"]:
+    if current not in ["ACN", "FuMa"]:
         raise ValueError("Invalid current channel convention. Has to be "
-                         f"'acn' or 'fuma', but is {current}")
+                         f"'ACN' or 'FuMa', but is {current}")
 
-    if target not in ["acn", "fuma"]:
-        raise ValueError("Invalid target channel convention. Has to be 'acn' "
-                         f"or 'fuma', but is {target}")
+    if target not in ["ACN", "FuMa"]:
+        raise ValueError("Invalid target channel convention. Has to be 'ACN' "
+                         f"or 'FuMa', but is {target}")
 
     acn = np.arange(data.shape[axis])
-    if current == 'acn':
+    if current == 'ACN':
         n, m = acn_to_nm(acn)
         idx = nm_to_fuma(n, m)
-    elif current == 'fuma':
+    elif current == 'FuMa':
         n, m = fuma_to_nm(acn)
         idx = nm_to_acn(n, m)
 
@@ -379,7 +380,7 @@ def change_channel_convention(data, current, target, axis):
 
 
 def spherical_harmonic_basis(
-        n_max, coordinates, normalization="N3D", channel_convention="acn",
+        n_max, coordinates, normalization="N3D", channel_convention="ACN",
         condon_shortley='auto'):
     r"""
     Calculates the complex valued spherical harmonic basis matrix.
@@ -418,8 +419,8 @@ def spherical_harmonic_basis(
         ``'SN3D'``, or ``'SNM'``.
         (maxN is only supported up to 3rd order)
     channel_convention : str, optional
-        Channel ordering convention, either ``'acn'`` or ``'fuma'``.
-        The default is ``'acn'``.
+        Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
+        The default is ``'ACN'``.
         (FuMa is only supported up to 3rd order)
     condon_shortley : bool or str, optional
         Whether to include the Condon-Shortley phase term. If ``True`` or
@@ -439,7 +440,7 @@ def spherical_harmonic_basis(
     >>> Y = spharpy.spherical.spherical_harmonic_basis(n_max, coordinates)
 
     """  # noqa: E501
-    if channel_convention == "fuma" and n_max > 3:
+    if channel_convention == "FuMa" and n_max > 3:
         raise ValueError(
             "FuMa channel convention is only supported up to 3rd order.")
 
@@ -459,7 +460,7 @@ def spherical_harmonic_basis(
     basis = np.zeros((coordinates.csize, n_coeff), dtype=complex)
 
     for acn in range(n_coeff):
-        if channel_convention == "fuma":
+        if channel_convention == "FuMa":
             order, degree = fuma_to_nm(acn)
         else:
             order, degree = acn_to_nm(acn)
@@ -483,7 +484,7 @@ def spherical_harmonic_basis(
 
 
 def spherical_harmonic_basis_gradient(n_max, coordinates, normalization="N3D",
-                                      channel_convention="acn",
+                                      channel_convention="ACN",
                                       condon_shortley='auto'):
     r"""
     Calculates the unit sphere gradients of the complex spherical harmonics.
@@ -545,7 +546,7 @@ def spherical_harmonic_basis_gradient(n_max, coordinates, normalization="N3D",
         spharpy.spherical.spherical_harmonic_basis_gradient(n_max, coordinates)
 
     """  # noqa: E501
-    if channel_convention == "fuma" and n_max > 3:
+    if channel_convention == "FuMa" and n_max > 3:
         raise ValueError(
             "FuMa channel convention is only supported up to 3rd order.")
 
@@ -568,7 +569,7 @@ def spherical_harmonic_basis_gradient(n_max, coordinates, normalization="N3D",
     grad_phi = np.zeros((n_points, n_coeff), dtype=complex)
 
     for acn in range(n_coeff):
-        if channel_convention == "fuma":
+        if channel_convention == "FuMa":
             n, m = fuma_to_nm(acn)
         else:
             n, m = acn_to_nm(acn)
@@ -601,7 +602,7 @@ def spherical_harmonic_basis_gradient(n_max, coordinates, normalization="N3D",
 
 
 def spherical_harmonic_basis_real(
-        n_max, coordinates, normalization="N3D", channel_convention="acn",
+        n_max, coordinates, normalization="N3D", channel_convention="ACN",
         condon_shortley='auto'):
     r"""
     Calculates the real valued spherical harmonic basis matrix.
@@ -628,8 +629,8 @@ def spherical_harmonic_basis_real(
         ``'SN3D'``, or ``'SNM'``.
         (maxN is only supported up to 3rd order)
     channel_convention : str, optional
-        Channel ordering convention, either ``'acn'`` or ``'fuma'``.
-        The default is ``'acn'``.
+        Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
+        The default is ``'ACN'``.
         (FuMa is only supported up to 3rd order)
     condon_shortley : bool or str, optional
         Whether to include the Condon-Shortley phase term. If ``True``,
@@ -642,7 +643,7 @@ def spherical_harmonic_basis_real(
         Real valued spherical harmonic basis matrix.
 
     """  # noqa: E501
-    if channel_convention == "fuma" and n_max > 3:
+    if channel_convention == "FuMa" and n_max > 3:
         raise ValueError(
             "FuMa channel convention is only supported up to 3rd order.")
 
@@ -662,7 +663,7 @@ def spherical_harmonic_basis_real(
     basis = np.zeros((coordinates.csize, n_coeff), dtype=float)
 
     for acn in range(n_coeff):
-        if channel_convention == "fuma":
+        if channel_convention == "FuMa":
             order, degree = fuma_to_nm(acn)
         else:
             order, degree = acn_to_nm(acn)
@@ -687,7 +688,7 @@ def spherical_harmonic_basis_real(
 
 def spherical_harmonic_basis_gradient_real(n_max, coordinates,
                                            normalization="N3D",
-                                           channel_convention="acn",
+                                           channel_convention="ACN",
                                            condon_shortley='auto'):
     r"""
     Calculates the unit sphere gradients of the real valued spherical
@@ -726,8 +727,8 @@ def spherical_harmonic_basis_gradient_real(n_max, coordinates,
         ``'maxN'``, ``'SN3D'``, or ``'SNM'``.
         (maxN is only supported up to 3rd order)
     channel_convention : str, optional
-        Channel ordering convention, either ``'acn'`` or ``'fuma'``.
-        The default is ``'acn'``.
+        Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
+        The default is ``'ACN'``.
         (FuMa is only supported up to 3rd order)
     condon_shortley : bool or str, optional
         Whether to include the Condon-Shortley phase term. If ``True``,
@@ -742,7 +743,7 @@ def spherical_harmonic_basis_gradient_real(n_max, coordinates,
         Gradient with respect to the azimuth angle.
 
     """  # noqa: E501
-    if channel_convention == "fuma" and n_max > 3:
+    if channel_convention == "FuMa" and n_max > 3:
         raise ValueError(
             "FuMa channel convention is only supported up to 3rd order.")
 
@@ -765,7 +766,7 @@ def spherical_harmonic_basis_gradient_real(n_max, coordinates,
     grad_phi = np.zeros((n_points, n_coeff), dtype=float)
 
     for acn in range(n_coeff):
-        if channel_convention == "fuma":
+        if channel_convention == "FuMa":
             n, m = fuma_to_nm(acn)
         else:
             n, m = acn_to_nm(acn)
@@ -1059,7 +1060,7 @@ def sid(n_max):
 
 def sid_to_acn(n_max):
     """Convert from SID channel indexing to ACN indeces.
-    Returns the indices to achieve a corresponding linear acn indexing.
+    Returns the indices to achieve a corresponding linear ACN indexing.
 
     Parameters
     ----------

--- a/tests/test_sh_class.py
+++ b/tests/test_sh_class.py
@@ -12,7 +12,7 @@ def test_spherical_harmonics_definition_init():
     definition = SphericalHarmonicDefinition()
     assert definition.basis_type == 'real'
     assert definition.normalization == 'N3D'
-    assert definition.channel_convention == 'acn'
+    assert definition.channel_convention == 'ACN'
     assert definition.condon_shortley is False
 
 
@@ -59,7 +59,7 @@ def test_setter_phase_convention_invalid():
         sph_harm.condon_shortley = "invalid"  # Invalid string
 
 
-@pytest.mark.parametrize("channel_convention", ["acn", "fuma"])
+@pytest.mark.parametrize("channel_convention", ["ACN", "FuMa"])
 def test_setter_channel_convention_definition(channel_convention):
     """Test setting channel convention for spherical harmonic definition."""
     sph_harm = SphericalHarmonicDefinition()
@@ -67,7 +67,7 @@ def test_setter_channel_convention_definition(channel_convention):
     assert sph_harm.channel_convention == channel_convention
 
 
-@pytest.mark.parametrize("channel_convention", ["acn", "fuma"])
+@pytest.mark.parametrize("channel_convention", ["ACN", "FuMa"])
 def test_init_channel_convention_definition(channel_convention):
     """Test initialization with different channel conventions."""
     sph_harm = SphericalHarmonicDefinition(
@@ -80,7 +80,7 @@ def test_setter_channel_convention_fuma_error():
     sph_harm = SphericalHarmonicDefinition(n_max=4)
 
     with pytest.raises(ValueError, match='n_max > 3 is not allowed with'):
-        sph_harm.channel_convention = "fuma"
+        sph_harm.channel_convention = "FuMa"
 
 
 def test_setter_channel_convention_definition_invalid():
@@ -132,7 +132,7 @@ def test_sh_definition_setter_n_max():
 
 
 @pytest.mark.parametrize(
-        ('norm', 'convention'), [('maxN', 'acn'), ('N3D', 'fuma')])
+        ('norm', 'convention'), [('maxN', 'ACN'), ('N3D', 'FuMa')])
 def test_sh_definition_setter_n_max_invalid_combinations(norm, convention):
     """Test error when setting n_max > 3 with incompatible combinations."""
     sph_harm = SphericalHarmonicDefinition(n_max=2)
@@ -205,7 +205,7 @@ def test_compute_basis_caching(icosahedron_sampling):
         n_max, icosahedron_sampling,
         basis_type='real',
         normalization='N3D',
-        channel_convention='acn',
+        channel_convention='ACN',
         condon_shortley=False,
     )
 
@@ -230,7 +230,7 @@ def test_compute_basis_caching(icosahedron_sampling):
     assert new_result is not last_result
     last_result = new_result
 
-    sh.channel_convention = 'fuma'
+    sh.channel_convention = 'FuMa'
     new_result = sh.basis
     assert new_result is not last_result
     last_result = new_result

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -12,7 +12,7 @@ def test_renormalize_errors():
 
     # test channel convention
     with pytest.raises(ValueError, match="Invalid channel convention. Has to "
-                                         "be 'acn' or 'fuma', but is "
+                                         "be 'ACN' or 'FuMa', but is "
                                          "wrong_channel_convention"):
         sh.renormalize(sh_data, 'wrong_channel_convention', 'maxN',
                        'N3D', axis=0)
@@ -22,17 +22,17 @@ def test_renormalize_errors():
                        match="Invalid current normalization. Has to be "
                              "'N3D', 'NM', 'maxN', 'SN3D', or 'SNM' "
                              "but is wrong_norm"):
-        sh.renormalize(sh_data, 'acn', 'wrong_norm', 'N3D', axis=0)
+        sh.renormalize(sh_data, 'ACN', 'wrong_norm', 'N3D', axis=0)
 
     # test target norm
     with pytest.raises(ValueError,
                        match="Invalid target normalization. Has to be "
                              "'N3D', 'NM', 'maxN', 'SN3D', or 'SNM' "
                              "but is wrong_norm"):
-        sh.renormalize(sh_data, 'acn', 'N3D', 'wrong_norm', axis=0)
+        sh.renormalize(sh_data, 'ACN', 'N3D', 'wrong_norm', axis=0)
 
 
-@pytest.mark.parametrize("channel_convention", ['acn', 'fuma'])
+@pytest.mark.parametrize("channel_convention", ['ACN', 'FuMa'])
 def test_renormalize(channel_convention):
     sh_data = np.ones((4, 2))
 
@@ -141,7 +141,7 @@ def test_renormalize_wrong_channel_number():
     with pytest.raises(
         ValueError, match=re.escape("Invalid number of SH channels: 5. "
                                     "It must match (n_max + 1)^2.")):
-        sh.renormalize(sh_data, 'acn', 'N3D', 'maxN', axis=0)
+        sh.renormalize(sh_data, 'ACN', 'N3D', 'maxN', axis=0)
 
 
 def test_change_channel_convention_errors():
@@ -149,14 +149,14 @@ def test_change_channel_convention_errors():
     # test current channel convention
     with pytest.raises(
             ValueError, match="Invalid current channel convention. Has to "
-            "be 'acn' or 'fuma', but is wrong"):
-        sh.change_channel_convention(sh_data, 'wrong', 'fuma', axis=0)
+            "be 'ACN' or 'FuMa', but is wrong"):
+        sh.change_channel_convention(sh_data, 'wrong', 'FuMa', axis=0)
 
     # test target channel convention
     with pytest.raises(
             ValueError, match="Invalid target channel convention. Has to "
-            "be 'acn' or 'fuma', but is wrong"):
-        sh.change_channel_convention(sh_data, 'fuma', 'wrong', axis=0)
+            "be 'ACN' or 'FuMa', but is wrong"):
+        sh.change_channel_convention(sh_data, 'FuMa', 'wrong', axis=0)
 
 
 def test_change_channel_convention():
@@ -165,17 +165,17 @@ def test_change_channel_convention():
                         [3., 3., 3.],
                         [4., 4., 4.]])
 
-    # test conversion to fuma
-    current_channel_convention = 'acn'
+    # test conversion to FuMa
+    current_channel_convention = 'ACN'
     sh_data_new_convention = sh.change_channel_convention(
-        sh_data, current_channel_convention, 'fuma', axis=0)
+        sh_data, current_channel_convention, 'FuMa', axis=0)
     sh_data_new_convention_fuma = sh_data[[0, 3, 1, 2], :]
     np.testing.assert_equal(sh_data_new_convention_fuma,
                             sh_data_new_convention)
 
     # test conversion to acn
-    current_channel_convention = 'fuma'
+    current_channel_convention = 'FuMa'
     sh_data_new_convention = sh.change_channel_convention(
-        sh_data_new_convention_fuma, current_channel_convention, 'acn', axis=0)
+        sh_data_new_convention_fuma, current_channel_convention, 'ACN', axis=0)
     np.testing.assert_equal(sh_data,
                             sh_data_new_convention)

--- a/tests/test_spherical_harmonics.py
+++ b/tests/test_spherical_harmonics.py
@@ -9,7 +9,7 @@ import pytest
 
 @pytest.mark.parametrize("implementation", ['spharpy', 'pyfar'])
 @pytest.mark.parametrize("normalization", ['N3D', 'NM', 'maxN', 'SN3D', 'SNM'])
-@pytest.mark.parametrize("channel_convention", ['acn', 'fuma'])
+@pytest.mark.parametrize("channel_convention", ['ACN', 'FuMa'])
 @pytest.mark.parametrize("condon_shortley", [True, False, 'auto'])
 def test_spherical_harmonic(make_coordinates, implementation,
                             normalization, channel_convention,
@@ -31,7 +31,7 @@ def test_spherical_harmonic(make_coordinates, implementation,
         norm_id = 'sn3d'
 
     Y = np.genfromtxt(f'./tests/data/Y_cmplx_{phase_conv_id}_'
-                      f'{norm_id}_{channel_convention}.csv',
+                      f'{norm_id}_{channel_convention.lower()}.csv',
                       dtype=complex,
                       delimiter=',')
     if normalization in ('NM', 'SNM'):
@@ -47,7 +47,7 @@ def test_spherical_harmonic(make_coordinates, implementation,
 
 @pytest.mark.parametrize("implementation", ['spharpy', 'pyfar'])
 @pytest.mark.parametrize("condon_shortley", [True, False, 'auto'])
-@pytest.mark.parametrize("channel_convention", ['acn', 'fuma'])
+@pytest.mark.parametrize("channel_convention", ['ACN', 'FuMa'])
 @pytest.mark.parametrize("normalization", ['N3D', 'SN3D'])
 def test_spherical_harmonics_real(make_coordinates, implementation,
                                   normalization, channel_convention,
@@ -69,7 +69,7 @@ def test_spherical_harmonics_real(make_coordinates, implementation,
         norm_id = 'sn3d'
 
     Y = np.genfromtxt(f'./tests/data/Y_real_{phase_conv_id}_'
-                      f'{norm_id}_{channel_convention}.csv',
+                      f'{norm_id}_{channel_convention.lower()}.csv',
                       dtype=float,
                       delimiter=',')
 
@@ -119,12 +119,12 @@ def test_spherical_harmonics_invalid_fuma(make_coordinates, implementation):
                        match='FuMa channel convention is only'
                              ' supported up to 3rd order.'):
         sh.spherical_harmonic_basis(n_max, coords,
-                                    channel_convention='fuma')
+                                    channel_convention='FuMa')
     with pytest.raises(ValueError,
                        match='FuMa channel convention is only'
                              ' supported up to 3rd order.'):
         sh.spherical_harmonic_basis_real(n_max, coords,
-                                         channel_convention='fuma')
+                                         channel_convention='FuMa')
 
 
 @pytest.mark.parametrize("implementation", ['spharpy', 'pyfar'])
@@ -324,9 +324,9 @@ def test_spherical_harmonics_gradient_invalid_fuma(make_coordinates,
                        match='FuMa channel convention is only'
                              ' supported up to 3rd order.'):
         sh.spherical_harmonic_basis_gradient(n_max, coords,
-                                             channel_convention='fuma')
+                                             channel_convention='FuMa')
     with pytest.raises(ValueError,
                        match='FuMa channel convention is only'
                              ' supported up to 3rd order.'):
         sh.spherical_harmonic_basis_gradient_real(n_max, coords,
-                                                  channel_convention='fuma')
+                                                  channel_convention='FuMa')

--- a/tests/test_spherical_harmonics_signal.py
+++ b/tests/test_spherical_harmonics_signal.py
@@ -13,7 +13,7 @@ def test_spherical_harmonic_signal_init():
                      [1., 2., 3.]]).reshape(1, 4, 3)
     signal = SphericalHarmonicSignal(data,
                                      44100, basis_type='real',
-                                     channel_convention='acn',
+                                     channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False)
     assert isinstance(signal, SphericalHarmonicSignal)
@@ -31,14 +31,14 @@ def test_spherical_harmonic_signal_init_condon_shortley():
                      [1., 2., 3.]]).reshape(1, 4, 3)
     signal = SphericalHarmonicSignal(data,
                                      44100, basis_type='real',
-                                     channel_convention='acn',
+                                     channel_convention='ACN',
                                      condon_shortley=False,
                                      normalization='N3D')
     assert not signal.condon_shortley
 
     signal = SphericalHarmonicSignal(data.astype(np.complex128),
                                      44100, basis_type='complex',
-                                     channel_convention='acn',
+                                     channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=True,
                                      is_complex=True)
@@ -59,7 +59,7 @@ def test_spherical_harmonic_signal_wrong_dimensions():
                       "at least 3 dimensions."):
         SphericalHarmonicSignal(data,
                                 44100, basis_type='real',
-                                channel_convention='acn',
+                                channel_convention='ACN',
                                 condon_shortley=False,
                                 normalization='N3D')
     # test if sh channels are valid
@@ -75,7 +75,7 @@ def test_spherical_harmonic_signal_wrong_dimensions():
                                 "(n_max + 1)^2.")):
         SphericalHarmonicSignal(data,
                                 44100, basis_type='real',
-                                channel_convention='acn',
+                                channel_convention='ACN',
                                 condon_shortley=False,
                                 normalization='N3D')
 
@@ -85,7 +85,7 @@ def test_spherical_harmonic_signal_init_multichannel():
     sh_coeffs = np.zeros((2, 4, 16))
     signal = SphericalHarmonicSignal(sh_coeffs,
                                      44100, basis_type='real',
-                                     channel_convention='acn',
+                                     channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False)
     assert isinstance(signal, SphericalHarmonicSignal)
@@ -99,7 +99,7 @@ def test_nmax_getter():
                      [1., 2., 3.]]).reshape(1, 4, 3)
     signal = SphericalHarmonicSignal(data,
                                      44100, basis_type='real',
-                                     channel_convention='acn',
+                                     channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False)
     assert signal.n_max == 1
@@ -116,7 +116,7 @@ def test_init_wrong_basis_type():
                       "'complex' and 'real' are supported"):
         SphericalHarmonicSignal(data,
                                 44100, basis_type='invalid_basis_type',
-                                channel_convention='acn',
+                                channel_convention='ACN',
                                 normalization='N3D',
                                 condon_shortley=False)
 
@@ -129,7 +129,7 @@ def test_basis_type_getter():
                      [1., 2., 3.]]).reshape(1, 4, 3)
     signal = SphericalHarmonicSignal(data,
                                      44100, basis_type='real',
-                                     channel_convention='acn',
+                                     channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False)
     assert signal.basis_type == 'real'
@@ -147,7 +147,7 @@ def test_init_wrong_normalization():
                              "invalid_normalization"):
         SphericalHarmonicSignal(data,
                                 44100, basis_type='real',
-                                channel_convention='acn',
+                                channel_convention='ACN',
                                 normalization='invalid_normalization',
                                 condon_shortley=False)
 
@@ -159,7 +159,7 @@ def test_spherical_harmonic_signal_normalization_setter():
                      [1., 2., 3.]]).reshape(1, 4, 3)
     signal = SphericalHarmonicSignal(data,
                                      44100, basis_type='real',
-                                     channel_convention='acn',
+                                     channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False)
     signal.normalization = 'SN3D'
@@ -185,8 +185,8 @@ def test_init_wrong_channel_convention():
                      [1., 2., 3.]]).reshape(1, 4, 3)
 
     with pytest.raises(ValueError,
-                match="Invalid channel convention, has to be 'acn' "
-                      "or 'fuma', but is invalid_convention"):
+                match="Invalid channel convention, has to be 'ACN' "
+                      "or 'FuMa', but is invalid_convention"):
         SphericalHarmonicSignal(data,
                                 44100, basis_type='real',
                                 channel_convention='invalid_convention',
@@ -201,11 +201,11 @@ def test_spherical_harmonic_signal_channel_convention_setter():
                      [1., 2., 3.]]).reshape(1, 4, 3)
     signal = SphericalHarmonicSignal(data,
                                      44100, basis_type='real',
-                                     channel_convention='acn',
+                                     channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False)
-    signal.channel_convention = 'fuma'
-    assert signal.channel_convention == 'fuma'
+    signal.channel_convention = 'FuMa'
+    assert signal.channel_convention == 'FuMa'
 
-    signal.channel_convention = 'acn'
-    assert signal.channel_convention == 'acn'
+    signal.channel_convention = 'ACN'
+    assert signal.channel_convention == 'ACN'


### PR DESCRIPTION
### Changes proposed in this pull request:

- Renames `acn` to `ACN` when used as input string
- Renames `fuma` to `FuMa` when used as input string
- Places where `acn` and `fuma` are used as variable names are not changed
- When referencing as names or equation symbols, they were also changed within docstrings
- examples were intentionally not touched.
