### PR TITLE
Add inherited-members option to spharpy.transforms

### DIFF
--- a/docs/modules/spharpy.transforms.rst
+++ b/docs/modules/spharpy.transforms.rst
@@ -7,3 +7,4 @@ spharpy.transforms
    :special-members: __init__
    :undoc-members:
    :show-inheritance:
+   :inherited-members:


### PR DESCRIPTION
This is required to show all inherited methods from the parent class in Sphinx