### PR TITLE
Plots/harmonize return parameter documentation

### DIFF
--- a/spharpy/plot/spatial.py
+++ b/spharpy/plot/spatial.py
@@ -537,14 +537,14 @@ def balloon(
 
     Returns
     -------
-    ax : matplotlib.axes.Axes
+    ax : matplotlib.axes.Axes, list[matplotlib.axes.Axes]
         If `colorbar` is ``True`` a list of two axes is returned. The first
         one is the axis on which the data is plotted, the second one is the
         axis of the colorbar. If `colorbar` is ``False``, only the axis on
         which the data is plotted is returned.
     plot : matplotlib.trisurf
         The trisurf object created by the function.
-    cb : matplotlib.colorbar.Colorbar
+    cb : matplotlib.colorbar.Colorbar, None
         The Matplotlib colorbar object if `colorbar` is ``True`` and ``None``
         otherwise. This can be used to control the appearance of the colorbar,
         e.g., the label can be set by ``colorbar.set_label()``.
@@ -939,14 +939,14 @@ def contour_map(
 
     Returns
     -------
-    ax : matplotlib.axes.Axes
+    ax : matplotlib.axes.Axes, list[matplotlib.axes.Axes]
         If `colorbar` is ``True`` a list of two axes is returned. The first
         one is the axis on which the data is plotted, the second one is the
         axis of the colorbar. If `colorbar` is ``False``, only the axis on
         which the data is plotted is returned.
     cf : matplotlib.contour.QuadContourSet
         The contour plot object.
-    cb : matplotlib.colorbar.Colorbar
+    cb : matplotlib.colorbar.Colorbar, None
         The Matplotlib colorbar object if `colorbar` is ``True`` and ``None``
         otherwise. This can be used to control the appearance of the colorbar,
         e.g., the label can be set by ``colorbar.set_label()``.


### PR DESCRIPTION
Merges into #222 

Review in an open pull suggested adding `None` as return type for _cb_ and `list[matplotlib.axes.Axes]` for _ax_ (see https://github.com/pyfar/spharpy/pull/224#discussion_r2572935501, https://github.com/pyfar/spharpy/pull/224#discussion_r2572936184)

This PR applies these changes to `balloon` and `contour_map`, which have already been merged into the collective branch.