### PR TITLE
Docs/Adjust example plots for balloon and balloon_wireframe

### DIFF
--- a/spharpy/plot/spatial.py
+++ b/spharpy/plot/spatial.py
@@ -484,7 +484,7 @@ def balloon_wireframe(
         >>> import spharpy
         >>> import numpy as np
         >>> coords = spharpy.samplings.equal_area(n_max=0, n_points=500)
-        >>> data = np.sin(coords.colatitude) * np.cos(coords.azimuth)
+        >>> data = np.sin(coords.azimuth) * np.cos(coords.elevation)
         >>> spharpy.plot.balloon_wireframe(coords, data, cmap_encoding='phase')
 
     """
@@ -651,7 +651,7 @@ def balloon(
         >>> import spharpy
         >>> import numpy as np
         >>> coords = spharpy.samplings.equal_area(n_max=0, n_points=500)
-        >>> data = np.sin(coords.colatitude) * np.cos(coords.azimuth)
+        >>> data = np.sin(coords.azimuth) * np.cos(coords.elevation)
         >>> spharpy.plot.balloon(coords, data, cmap_encoding='phase')
 
     """


### PR DESCRIPTION
Merges into #222 

### Changes proposed in this pull request:

- Adding the pyfar plot style in #257 did not improve the colorbar placement in balloon-like plots (see new baseline plots #242) 
- To get better looking examples in the docs, the data is adjusted so the balloon-data extends in x-direction

### Note

A general guide on how to generate plots without overlap issues will be added to the docs in a separate pull (#263).
### Example

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/e7f0f90d-bdb0-458a-98ca-b03834299d9f" width="400"/> | <img src="https://github.com/user-attachments/assets/33f6f235-5b9e-4358-912d-500de0eeb66a" width="400"/> |


