### PR TITLE
[DOC] Unify documentation of SH parameters and properties

### DIFF
--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -132,15 +132,16 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
         Type of spherical harmonic basis, either ``'complex'`` or
         ``'real'``.
     normalization : str
-        Normalization convention, either ``'N3D'``, ``'NM'``,
-        ``'maxN'``, ``'SN3D'`` or ``'SNM'``. (maxN is only supported up
-        to 3rd order)
+        Normalization convention, either ``'N3D'``, ``'NM'``, ``'SN3D'``,
+        ``'SNM'``, or ``'maxN'``. ``'maxN'`` is only supported up to 3rd order.
     channel_convention : str
         Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
-        (FuMa is only supported up to 3rd order)
+        ``'FuMa'`` is only supported up to 3rd order.
     condon_shortley : bool
-        Flag to indicate if the Condon-Shortley phase term is included
-        (``True``) or not (``False``).
+        Whether to include the Condon-Shortley phase term. If ``True``,
+        Condon-Shortley is included, if ``False`` it is not
+        included. ``'auto'`` corresponds to ``True`` for complex `basis_type`
+        and ``False`` for real `basis_type`.
     domain : ``'time'``, ``'freq'``, optional
         Domain of data. The default is ``'time'``
     comment : str
@@ -165,7 +166,7 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
 
     @_SphericalHarmonicBase.basis_type.setter
     def basis_type(self, value):
-        """Get or set the type of spherical harmonic basis."""
+        """Get or set the spherical harmonic basis type."""
 
         # Make sure that the basis type can only be set during initialization.
         # Changing it afterwards requires implementing the conversion between
@@ -212,9 +213,11 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
     channel_convention : str
         Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
         (FuMa is only supported up to 3rd order)
-    condon_shortley : bool
-        Flag to indicate if the Condon-Shortley phase term is included
-        (``True``) or not (``False``).
+    condon_shortley : bool or str
+        Whether to include the Condon-Shortley phase term. If ``True``,
+        Condon-Shortley is included, if ``False`` it is not
+        included. ``'auto'`` corresponds to ``True`` for complex `basis_type`
+        and ``False`` for real `basis_type`.
     comment : str
         A comment related to `data`. The default is ``""``.
     is_complex : bool, optional
@@ -287,15 +290,16 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
         Type of spherical harmonic basis, either ``'complex'`` or
         ``'real'``.
     normalization : str
-        Normalization convention, either ``'N3D'``, ``'NM'``,
-        ``'maxN'``, ``'SN3D'`` or ``'SNM'``. (maxN is only supported up
-        to 3rd order)
+        Normalization convention, either ``'N3D'``, ``'NM'``, ``'SN3D'``,
+        ``'SNM'``, or ``'maxN'``. ``'maxN'`` is only supported up to 3rd order.
     channel_convention : str
         Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
-        (FuMa is only supported up to 3rd order)
-    condon_shortley : bool
-        Flag to indicate if the Condon-Shortley phase term is included
-        (``True``) or not (``False``).
+        ``'FuMa'`` is only supported up to 3rd order.
+    condon_shortley : bool or str
+        Whether to include the Condon-Shortley phase term. If ``True``,
+        Condon-Shortley is included, if ``False`` it is not
+        included. ``'auto'`` corresponds to ``True`` for complex `basis_type`
+        and ``False`` for real `basis_type`.
     comment : str
         A comment related to `data`. The default is ``""``.
     """
@@ -366,15 +370,16 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         Type of spherical harmonic basis, either ``'complex'`` or
         ``'real'``.
     normalization : str
-        Normalization convention, either ``'N3D'``, ``'NM'``,
-        ``'maxN'``, ``'SN3D'`` or ``'SNM'``. (maxN is only supported up
-        to 3rd order)
+        Normalization convention, either ``'N3D'``, ``'NM'``, ``'SN3D'``,
+        ``'SNM'``, or ``'maxN'``. ``'maxN'`` is only supported up to 3rd order.
     channel_convention : str
         Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
-        (FuMa is only supported up to 3rd order)
-    condon_shortley : bool
-        Flag to indicate if the Condon-Shortley phase term is included
-        (``True``) or not (``False``).
+        ``'FuMa'`` is only supported up to 3rd order.
+    condon_shortley : bool or str
+        Whether to include the Condon-Shortley phase term. If ``True``,
+        Condon-Shortley is included, if ``False`` it is not
+        included. ``'auto'`` corresponds to ``True`` for complex `basis_type`
+        and ``False`` for real `basis_type`.
     n_samples : int, optional
         Number of time domain samples. Required if domain is ``'freq'``.
         The default is ``None``, which assumes an even number of samples

--- a/spharpy/classes/coordinates.py
+++ b/spharpy/classes/coordinates.py
@@ -64,7 +64,8 @@ class SamplingSphere(pf.Coordinates):
             Z coordinate of a right handed Cartesian coordinate system in
             meters (-\infty < z < \infty).
         n_max : int, optional
-            Maximum spherical harmonic order of the sampling grid.
+            Maximum spherical harmonic order of the sampling grid. If
+            provided, it must be an integer greater or equal to 0.
             The default is ``None``.
         weights: array like, number, optional
             Weighting factors for coordinate points. Their sum must equal to
@@ -509,12 +510,12 @@ class SamplingSphere(pf.Coordinates):
 
     @property
     def n_max(self):
-        """Get the maximum spherical harmonic order."""
+        """Get or set the spherical harmonic order."""
         return self._n_max
 
     @n_max.setter
     def n_max(self, value):
-        """Set the maximum spherical harmonic order."""
+        """Get or set the spherical harmonic order."""
         assert value >= 0
 
         if value is None:

--- a/spharpy/classes/sh.py
+++ b/spharpy/classes/sh.py
@@ -162,23 +162,24 @@ class SphericalHarmonicDefinition(_SphericalHarmonicBase):
     Attributes
     ----------
     n_max : int, optional
-        Maximum spherical harmonic order. The default is ``0``.
+        Maximum spherical harmonic order. Must be an integer greater or equal
+        to 0. The default is ``0``.
     basis_type : str
-        Type of spherical harmonic basis, either ``'real'`` or ``'complex'``.
-        The default is ``'real'``.
+        Type of spherical harmonic basis, either ``'complex'`` or
+        ``'real'``. The default is ``'real'``.
     channel_convention : str, optional
         Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
-        The default is ``'ACN'``. Note that ``'FuMa'`` is only supported up to
-        3rd order.
+        ``'FuMa'`` is only supported up to 3rd order.
+        The default is ``'ACN'``.
     normalization : str, optional
-        Normalization convention, either ``'N3D'``, ``'NM'``, ``'maxN'``,
-        ``'SN3D'``, or ``'SNM'``. The default is ``'N3D'``. Note that
-        ``'maxN'`` is only supported up to 3rd order.
+        Normalization convention, either ``'N3D'``, ``'NM'``, ``'SN3D'``,
+        ``'SNM'``, or ``'maxN'``. ``'maxN'`` is only supported up to 3rd order.
+        The default is ``'N3D'``.
     condon_shortley : bool, str, optional
-        Condon-Shortley phase term. If ``True``, Condon-Shortley is included,
-        if ``False`` it is not included. The default is ``'auto'``, which
-        corresponds to ``True`` for type ``complex`` and ``False`` for type
-        ``real``.
+         Whether to include the Condon-Shortley phase term. If ``True``,
+        Condon-Shortley is included, if ``False`` it is not
+        included. The default is ``'auto'``, which corresponds to
+        ``True`` for complex `basis_type` and ``False`` for real `basis_type`.
     """
 
     def __init__(
@@ -300,7 +301,7 @@ class SphericalHarmonics(SphericalHarmonicDefinition):
 
     @classmethod
     def from_definition(cls, definition, coordinates, inverse_method="auto"):
-        """
+        r"""
         Create SphericalHarmonics instance from SphericalHarmonicDefinition.
 
         Parameters


### PR DESCRIPTION
### Changes proposed in this pull request:

We agreed on docstrings for SH related parameters and properties in #260. This PR applies the changes everywhere. Note that docstrings of the same parameter can be slightly different because parameters have a default in some cases while in others they don't (by intention).