### PR TITLE
Refactor samplings.fliege

### DIFF
--- a/spharpy/samplings/samplings.py
+++ b/spharpy/samplings/samplings.py
@@ -1132,9 +1132,13 @@ def fliege(n_max, radius=1.):
     r"""
     Return Fliege-Maier spherical sampling grid.
 
-    For detailed information, see [#]_. This is a
-    quadrature sampling with the sum of the sampling weights in
-    `sampling.weights` being :math:`4\pi`.
+    For detailed information, see [#]_.
+
+    .. note::
+        This is intended to be a quadrature sampling with positive sampling
+        weights summing to :math:`4\pi`. For unknown reasons, this is not the
+        case for orders 10, 12, 18, 20, 24, 26, 27, and 29. For this reason,
+        the respective weights are not returned regardless of the order.
 
     Parameters
     ----------
@@ -1147,8 +1151,8 @@ def fliege(n_max, radius=1.):
     Returns
     -------
     sampling : :py:class:`spharpy.SamplingSphere`
-        Sampling positions including sampling weights of csize
-        ``(n_max + 1)**2``.
+        ``(n_max + 1)**2`` sampling positions without sampling weights
+        (see note above).
 
     Notes
     -----

--- a/tests/test_samplings.py
+++ b/tests/test_samplings.py
@@ -471,6 +471,26 @@ def test_fliege_for_each_order(n_max):
     npt.assert_allclose(c.radius, 1, atol=1e-15)
 
 
+@pytest.mark.parametrize("n_max", [
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    22, 23, 24, 25, 26, 27, 28, 29])
+def test_fliege_orthogonality(n_max):
+    """
+    Test orthogonality of the transform.
+
+    This was done after discovering https://github.com/pyfar/spharpy/issues/202
+    to make sure that the sampling can be used for SH transforms using the
+    pseudo inverse.
+    """
+
+    sampling = samplings.fliege(n_max)
+    Y = spherical_harmonic_basis_real(n_max, sampling)
+    Y_inverse = np.linalg.pinv(Y)
+
+    # if orthogonal Y_inverse @ Y must be the identity matrix
+    npt.assert_allclose(Y_inverse @ Y, np.eye((n_max + 1)**2), atol=1e-12)
+
+
 def test_fliege_radius():
     # test user radius
     c = samplings.fliege(1, radius=1.5)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #202

### Changes proposed in this pull request:

- remove redundant ``n_points`` parameter
- remove table and add equation to doc
- simplify input check 
- split large tests into sep smaller tests
- add a test for each valid n_max. 

### open issues

currently the test is faling for n_max = 10, 12, 18, 20, 24, 26, 27, 29. The reason is negative weights for a few entries. If I do absolute, the weights do not sum up to 4pi. The bug must be in the [SOFiA](https://audiogroup.web.th-koeln.de/SOFiA_wiki/DOWNLOAD.html) toolbox., because they are precalculated and we just read them from disk.

- [ ] fix failing tests. 