### PR TITLE
Unify parameter order in sh classes

### DIFF
--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -153,8 +153,8 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
         _SphericalHarmonicBase.__init__(
             self,
             basis_type,
-            channel_convention,
             normalization,
+            channel_convention,
             condon_shortley)
 
     @property

--- a/spharpy/classes/sh.py
+++ b/spharpy/classes/sh.py
@@ -21,14 +21,14 @@ class _SphericalHarmonicBase(ABC):
     basis_type : str
         Type of spherical harmonic basis, either ``'real'`` or ``'complex'``.
         The default is ``'real'``.
-    channel_convention : str, optional
-        Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
-        The default is ``'ACN'``. Note that ``'FuMa'`` is only supported up to
-        3rd order.
     normalization : str, optional
         Normalization convention, either ``'N3D'``, ``'NM'``, ``'maxN'``,
         ``'SN3D'``, or ``'SNM'``. The default is ``'N3D'``. Note that
         ``'maxN'`` is only supported up to 3rd order.
+    channel_convention : str, optional
+        Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
+        The default is ``'ACN'``. Note that ``'FuMa'`` is only supported up to
+        3rd order.
     condon_shortley : bool, str, optional
         Condon-Shortley phase term. If ``True``, Condon-Shortley is included,
         if ``False`` it is not included. The default is ``'auto'``, which
@@ -39,8 +39,8 @@ class _SphericalHarmonicBase(ABC):
     def __init__(
             self,
             basis_type="real",
-            channel_convention="ACN",
             normalization="N3D",
+            channel_convention="ACN",
             condon_shortley="auto",
         ):
         self._basis_type = None
@@ -167,14 +167,14 @@ class SphericalHarmonicDefinition(_SphericalHarmonicBase):
     basis_type : str
         Type of spherical harmonic basis, either ``'complex'`` or
         ``'real'``. The default is ``'real'``.
-    channel_convention : str, optional
-        Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
-        ``'FuMa'`` is only supported up to 3rd order.
-        The default is ``'ACN'``.
     normalization : str, optional
         Normalization convention, either ``'N3D'``, ``'NM'``, ``'SN3D'``,
         ``'SNM'``, or ``'maxN'``. ``'maxN'`` is only supported up to 3rd order.
         The default is ``'N3D'``.
+    channel_convention : str, optional
+        Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
+        ``'FuMa'`` is only supported up to 3rd order.
+        The default is ``'ACN'``.
     condon_shortley : bool, str, optional
          Whether to include the Condon-Shortley phase term. If ``True``,
         Condon-Shortley is included, if ``False`` it is not
@@ -186,15 +186,15 @@ class SphericalHarmonicDefinition(_SphericalHarmonicBase):
             self,
             n_max=0,
             basis_type="real",
-            channel_convention="ACN",
             normalization="N3D",
+            channel_convention="ACN",
             condon_shortley="auto",
         ):
         self._n_max = 0
         super().__init__(
             basis_type=basis_type,
-            channel_convention=channel_convention,
             normalization=normalization,
+            channel_convention=channel_convention,
             condon_shortley=condon_shortley,
         )
         self.n_max = n_max
@@ -286,8 +286,8 @@ class SphericalHarmonics(SphericalHarmonicDefinition):
         super().__init__(
             n_max=n_max,
             basis_type=basis_type,
-            channel_convention=channel_convention,
             normalization=normalization,
+            channel_convention=channel_convention,
             condon_shortley=condon_shortley,
         )
 


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #266

### Changes proposed in this pull request:

- Change order of parameters in `_SphericalHarmonicBase` and `SphericalHarmonicDefinition`
- No updates of tests required because parameters were always calles as key-value arguments
