### PR TITLE
DOC: Increase navigation depth for left sidebar of the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,7 +136,7 @@ html_theme_options = {
     "secondary_sidebar_items": ["page-toc"],  # Omit 'show source' link that that shows notebook in json format
     "navigation_with_keys": True,
     # Configure navigation depth for section navigation
-    "navigation_depth": 1,
+    "navigation_depth": 2,
 }
 
 html_context = {


### PR DESCRIPTION
### Changes proposed in this pull request:

- Add subpage navigation to the left side-bar of the docs

This allows easier navigation between sub-modules and other sub-pages of the docs.

We've already implemented this change in pyfar. I'm adding this manually here as well since we're waiting for the new template in copier to be finished.