### PR TITLE
[MAINT] add python version 3.14 to ci and pipy metadata as supported version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,12 +168,13 @@ workflows:
                 - "3.11"
                 - "3.12"
                 - "3.13"
+                - "3.14"
 
       - ruff:
           matrix:
             parameters:
               version:
-                - "3.13"
+                - "3.14"
           requires:
             - build_and_test
 
@@ -181,7 +182,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.13"
+                - "3.14"
           requires:
             - build_and_test
 
@@ -189,7 +190,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.13"
+                - "3.14"
           requires:
             - build_and_test
 
@@ -197,7 +198,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.13"
+                - "3.14"
           requires:
             - build_and_test
 
@@ -213,6 +214,7 @@ workflows:
                 - "3.11"
                 - "3.12"
                 - "3.13"
+                - "3.14"
 
           filters:
             branches:
@@ -225,7 +227,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.13"
+                - "3.14"
           requires:
             - build_and_test
           filters:
@@ -239,7 +241,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.13"
+                - "3.14"
           requires:
             - build_and_test
           filters:
@@ -253,7 +255,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.13"
+                - "3.14"
           requires:
             - build_and_test
           filters:
@@ -267,7 +269,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.13"
+                - "3.14"
           requires:
             - build_and_test
             - ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 
 ]
 dependencies = [


### PR DESCRIPTION
### Changes proposed in this pull request:

- add python version 3.14 to ci and pipy metadata as supported version
