### PR TITLE
Automatically add copybutton to code cells in the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ extensions = [
     'sphinx_favicon',
     'sphinx_reredirects',
     'sphinx_mdinclude',
+    'sphinx_copybutton',
 ]
 
 # show tocs for classes and functions of modules using the autodocsumm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ docs = [
     "sphinx-design",
     "sphinx-favicon",
     "sphinx-reredirects",
+    "sphinx-copybutton",
 ]
 dev = ["spharpy[deploy,tests,docs]"]
 


### PR DESCRIPTION
### Changes proposed in this pull request:

- Add a copybutton to each code cell
- Uses the sphinx-copybutton package which implements the functionality as a sphinx plug-in
