### PR TITLE
enable data as list as input for SHAudio classes

### DIFF
--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -15,7 +15,8 @@ def _atleast_3d_first_dimension(data):
     Adds a singleton dimensions at the front if necessary.
     """
 
-    return np.atleast_2d(data)[np.newaxis, ...] if data.ndim < 3 else data
+    data = np.atleast_2d(data)
+    return data[np.newaxis, ...] if data.ndim < 3 else data
 
 
 def _assert_valid_number_of_sh_channels(shape):

--- a/tests/test_spherical_harmonics_audio.py
+++ b/tests/test_spherical_harmonics_audio.py
@@ -4,22 +4,33 @@ from spharpy.classes.audio import (
     _atleast_3d_first_dimension)
 from spharpy import SphericalHarmonicDefinition
 import numpy as np
+import numpy.testing as npt
 
 
 def test_atleast_3d_data():
+    """Test extending the shape of 1D and 2D array likes."""
+
+    # Prepend dimension for 2D array
     data = np.ones((4, 4))
     data_3d = _atleast_3d_first_dimension(data)
     assert data_3d.ndim == 3
     assert data_3d.shape == (1, 4, 4)
 
+    # Do not change 3D array
     data_3d = _atleast_3d_first_dimension(np.ones((2, 4, 4)))
 
     assert data_3d.ndim == 3
     assert data_3d.shape == (2, 4, 4)
 
-    data_3d = _atleast_3d_first_dimension(np.array(1))
+    # Prepend two dimensions for 1D array
+    data_3d = _atleast_3d_first_dimension(np.array([1, 2, 3, 4]))
     assert data_3d.ndim == 3
-    assert data_3d.shape == (1, 1, 1)
+    assert data_3d.shape == (1, 1, 4)
+
+    # Convert lists to numpy array
+    data = [1, 2, 3, 4]
+    data_3d_list = _atleast_3d_first_dimension(data)
+    npt.assert_equal(data_3d_list, data_3d)
 
 
 def test_init_sh_time_data():


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Big whoopsie: The SH audio classes crashed if the input data was provided as a list

### Changes proposed in this pull request:

- fix bug
- update tests
