### PR TITLE
Change the required pyfar version to min 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     'scipy>=1.17',
     'urllib3',
     'matplotlib>=3.10.3',
-    'pyfar @ git+https://github.com/pyfar/pyfar@develop',
+    'pyfar>=0.8.0',
     'pytz',
 ]
 


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #300 

### Changes proposed in this pull request:

- Installation from GitHub is currently required since to inherit from the newly introduced Rotation class
- After release of version 0.8.0 install via git can be replaced again.

**Note** This branch needs to be merged before releasing the next version of spharpy.
