### PR TITLE
remove pytz from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use pip to install spharpy
 
     pip install spharpy
 
-(Requires Python 3.10 or higher)
+(Requires Python 3.11 or higher)
 
 Audio file reading/writing is supported through [SoundFile](https://python-soundfile.readthedocs.io), which is based on
 [libsndfile](http://www.mega-nerd.com/libsndfile/). On Windows and OS X, it will be installed automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     'urllib3',
     'matplotlib>=3.10.3',
     'pyfar>=0.8.0',
-    'pytz',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Changes proposed in this pull request:

- Remove pytz from dependencies 
- Discouraged to use, see https://pypi.org/project/pytz/