### PR TITLE
MAINT: Create CircleCI job to test against wheels (binary distributions)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,20 +62,16 @@ jobs:
           command: |
             python -m build --wheel
       - run:
-          name: Install wheel in isolated venv and remove all source files from the test environment
+          name: Install wheel in isolated venv and run tests
           command: |
             python -m venv .wheeltest
             WHEEL=$(ls -1 dist/*.whl | head -n 1)
-            .wheeltest/bin/python -m pip install "$WHEEL"
-            .wheeltest/bin/python -c "import pathlib, spharpy; p = pathlib.Path(spharpy.__file__).resolve(); print(p); assert 'site-packages' in str(p), p"
+            .wheeltest/bin/python -m pip install "$WHEEL"[tests]
             TEST_PYTHON="$(pwd)/.wheeltest/bin/python"
             rm -rf /tmp/spharpy-wheel-tests
-      - run:
-          name: Run tests with wheel installation
-          command: |
             cp -r tests /tmp/spharpy-wheel-tests
             cd /tmp/spharpy-wheel-tests
-            "$TEST_PYTHON" -m pytest tests
+            "$TEST_PYTHON" -m pytest .
 
   ruff:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,6 @@ jobs:
             # Find the wheel file in the workspace and save it to an environment variable
             WHEEL=$(ls -1 /tmp/workspace/dist/*.whl | head -n 1)
             .wheeltest/bin/python -m pip install "${WHEEL}[tests]"
-            # Create an environment variable for the path to the python executable of the isolated venv
-            TEST_PYTHON="$(pwd)/.wheeltest/bin/python"
       - run:
           name: Move test files to isolated location
           command: |
@@ -97,6 +95,8 @@ jobs:
       - run:
           name: Run tests against wheel installation (i.e. in isolated environment)
           command: |
+            # Create an environment variable for the path to the python executable of the isolated venv
+            TEST_PYTHON="$(pwd)/.wheeltest/bin/python"
             cd /tmp/spharpy-wheel-tests
             "$TEST_PYTHON" -m pytest tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,11 @@ workflows:
           requires:
             - test_source
             - build_distribution
+          filters:
+            branches:
+              only:
+                - main
+                - develop
 
 
   test_and_publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,9 +121,6 @@ jobs:
       version: <<parameters.version>>
     steps:
       - checkout
-   #    - run:
-   #        name: Install System Dependencies
-   #        command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-latex-extra dvipng
       - run:
           name: Sphinx
           command: |
@@ -142,9 +139,6 @@ jobs:
       version: <<parameters.version>>
     steps:
       - checkout
-   #    - run:
-   #        name: Install System Dependencies
-   #        command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-latex-extra dvipng
       - run:
           name: install dependencies
           command: pip install ".[tests]"
@@ -167,9 +161,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: /tmp/workspace
-    #  - run:
-    #      name: Install System Dependencies
-    #      command: sudo apt-get update && sudo apt-get install -y libsndfile1
       - run:
           name: install dependencies
           command: pip install ".[deploy]"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,11 @@ jobs:
       - run:
           name: Install wheel from workspace in isolated venv
           command: |
-            python -m venv .wheeltest
+            rm -rf /tmp/wheeltest
+            python -m venv /tmp/wheeltest
             # Find the wheel file in the workspace and save it to an environment variable
             WHEEL=$(ls -1 /tmp/workspace/dist/*.whl | head -n 1)
-            .wheeltest/bin/python -m pip install "${WHEEL}[tests]"
+            /tmp/wheeltest/bin/python -m pip install "${WHEEL}[tests]"
       - run:
           name: Move test files to isolated location
           command: |
@@ -95,10 +96,8 @@ jobs:
       - run:
           name: Run tests against wheel installation (i.e. in isolated environment)
           command: |
-            # Create an environment variable for the path to the python executable of the isolated venv
-            TEST_PYTHON="$(pwd)/.wheeltest/bin/python"
             cd /tmp/spharpy-wheel-tests
-            "$TEST_PYTHON" -m pytest tests
+            /tmp/wheeltest/bin/python -m pytest tests
 
   ruff:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,14 +287,14 @@ workflows:
             parameters:
               version:
                 - "3.14"
+          requires:
+            - test_source
           filters:
             branches:
               ignore: /.*/
             # only act on version tags
             tags:
               only: /^v[0-9]+(\.[0-9]+)*$/
-            requires:
-              - test_source
 
       - ruff:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - checkout
       - run:
           name: install dependencies
-          command: pip install ".[tests]"
+          command: pip install ".[deploy,tests]"
       - run:
           name: Build wheel
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,13 +66,13 @@ jobs:
           command: |
             python -m venv .wheeltest
             WHEEL=$(ls -1 dist/*.whl | head -n 1)
-            .wheeltest/bin/python -m pip install "$WHEEL"[tests]
+            .wheeltest/bin/python -m pip install "${WHEEL}[tests]"
             TEST_PYTHON="$(pwd)/.wheeltest/bin/python"
             rm -rf /tmp/spharpy-wheel-tests
-            mkdir -p /tmp/spharpy-wheel-tests/tests
-            cp -r tests /tmp/spharpy-wheel-tests/tests/
+            mkdir -p /tmp/spharpy-wheel-tests
+            cp -r tests /tmp/spharpy-wheel-tests/
             cd /tmp/spharpy-wheel-tests
-            "$TEST_PYTHON" -m pytest .
+            "$TEST_PYTHON" -m pytest tests
 
   ruff:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,29 @@ executors:
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
+  build_distribution:
+    parameters:
+      version:
+        description: "version tag"
+        default: "latest"
+        type: string
+    executor:
+      name: python-docker
+      version: <<parameters.version>>
+    steps:
+      - checkout
+      - run:
+          name: install build dependencies
+          command: pip install ".[deploy]"
+      - run:
+          name: Build distribution artifacts
+          command: |
+            python -m build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
+
   test_source:
     parameters:
       version:
@@ -54,18 +77,13 @@ jobs:
       version: <<parameters.version>>
     steps:
       - checkout
-      - run:
-          name: install dependencies
-          command: pip install ".[deploy,tests]"
-      - run:
-          name: Build wheel
-          command: |
-            python -m build --wheel
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Install wheel in isolated venv and run tests
           command: |
             python -m venv .wheeltest
-            WHEEL=$(ls -1 dist/*.whl | head -n 1)
+            WHEEL=$(ls -1 /tmp/workspace/dist/*.whl | head -n 1)
             .wheeltest/bin/python -m pip install "${WHEEL}[tests]"
             TEST_PYTHON="$(pwd)/.wheeltest/bin/python"
             rm -rf /tmp/spharpy-wheel-tests
@@ -147,6 +165,8 @@ jobs:
       version: <<parameters.version>>
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/workspace
     #  - run:
     #      name: Install System Dependencies
     #      command: sudo apt-get update && sudo apt-get install -y libsndfile1
@@ -155,9 +175,8 @@ jobs:
           command: pip install ".[deploy]"
       - run:
           name: deploy
-          command: |  # create whl, install twine and publish to Test PyPI
-            python -m build
-            twine check dist/*
+          command: |
+            twine check /tmp/workspace/dist/*
 
   run_pypi_publish:
     parameters:
@@ -170,6 +189,8 @@ jobs:
       version: <<parameters.version>>
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Install System Dependencies
           command: sudo apt-get update && sudo apt-get install -y libsndfile1
@@ -178,16 +199,21 @@ jobs:
           command: pip install ".[deploy]"
       - run:
           name: deploy
-          command: |  # create whl, install twine and publish to Test PyPI
-            python -m build
-            twine check dist/*
-            twine upload dist/*
+          command: |
+            twine check /tmp/workspace/dist/*
+            twine upload /tmp/workspace/dist/*
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
   test: # Test workflow
     jobs:
+      - build_distribution:
+          matrix:
+            parameters:
+              version:
+                - "3.14"
+
       # Run tests for all python versions
       - test_source:
           matrix:
@@ -214,6 +240,8 @@ workflows:
                 - "3.12"
                 - "3.13"
                 - "3.14"
+          requires:
+            - build_distribution
 
       - test_documentation_build:
           matrix:
@@ -238,12 +266,25 @@ workflows:
                 - "3.14"
           requires:
             - test_source
+            - build_distribution
 
 
   test_and_publish:
     # Test and publish on new git version tags
     # This requires its own workflow to successfully trigger the test and build
     jobs:
+      - build_distribution:
+          matrix:
+            parameters:
+              version:
+                - "3.14"
+          filters:
+            branches:
+              ignore: /.*/
+            # only act on version tags
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*$/
+
       - test_source:
           matrix:
             parameters:
@@ -284,6 +325,7 @@ workflows:
                 - "3.14"
           requires:
             - test_source
+            - build_distribution
           filters:
             branches:
               ignore: /.*/
@@ -327,6 +369,7 @@ workflows:
           requires:
             - test_source
             - test_wheel
+            - build_distribution
             - ruff
             - test_documentation_build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ executors:
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  build_and_test:
+  test_source:
     parameters:
       version:
         description: "version tag"
@@ -36,9 +36,6 @@ jobs:
       version: <<parameters.version>>
     steps:
       - checkout
-    #   - run:
-    #       name: Install System Dependencies
-    #       command: sudo apt-get update && sudo apt-get install -y libsndfile1
       - run:
           name: install dependencies
           command: pip install ".[tests]"
@@ -195,7 +192,7 @@ workflows:
   test: # Test workflow
     jobs:
       # Run tests for all python versions
-      - build_and_test:
+      - test_source:
           matrix:
             parameters:
               version:
@@ -210,7 +207,7 @@ workflows:
               version:
                 - "3.14"
           requires:
-            - build_and_test
+            - test_source
 
       - test_wheel:
           matrix:
@@ -221,7 +218,7 @@ workflows:
                 - "3.13"
                 - "3.14"
           requires:
-            - build_and_test
+            - test_source
 
       - test_documentation_build:
           matrix:
@@ -229,7 +226,7 @@ workflows:
               version:
                 - "3.14"
           requires:
-            - build_and_test
+            - test_source
 
       - test_deprecation_warnings:
           matrix:
@@ -237,7 +234,7 @@ workflows:
               version:
                 - "3.14"
           requires:
-            - build_and_test
+            - test_source
 
       - test_pypi_publish:
           matrix:
@@ -245,15 +242,14 @@ workflows:
               version:
                 - "3.14"
           requires:
-            - build_and_test
-            - test_wheel
+            - test_source
 
 
   test_and_publish:
     # Test and publish on new git version tags
     # This requires its own workflow to successfully trigger the test and build
     jobs:
-      - build_and_test:
+      - test_source:
           matrix:
             parameters:
               version:
@@ -275,7 +271,7 @@ workflows:
               version:
                 - "3.14"
           requires:
-            - build_and_test
+            - test_source
           filters:
             branches:
               ignore: /.*/
@@ -292,7 +288,7 @@ workflows:
                 - "3.13"
                 - "3.14"
           requires:
-            - build_and_test
+            - test_source
           filters:
             branches:
               ignore: /.*/
@@ -306,7 +302,7 @@ workflows:
               version:
                 - "3.14"
           requires:
-            - build_and_test
+            - test_source
           filters:
             branches:
               ignore: /.*/
@@ -320,7 +316,7 @@ workflows:
               version:
                 - "3.14"
           requires:
-            - build_and_test
+            - test_source
           filters:
             branches:
               ignore: /.*/
@@ -334,7 +330,7 @@ workflows:
               version:
                 - "3.14"
           requires:
-            - build_and_test
+            - test_source
             - test_wheel
             - ruff
             - test_documentation_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,8 +217,6 @@ workflows:
                 - "3.12"
                 - "3.13"
                 - "3.14"
-          requires:
-            - test_source
 
       - test_documentation_build:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,12 +208,6 @@ jobs:
 workflows:
   test: # Test workflow
     jobs:
-      - build_distribution:
-          matrix:
-            parameters:
-              version:
-                - "3.14"
-
       # Run tests for all python versions
       - test_source:
           matrix:
@@ -223,6 +217,14 @@ workflows:
                 - "3.12"
                 - "3.13"
                 - "3.14"
+
+      - build_distribution:
+          matrix:
+            parameters:
+              version:
+                - "3.14"
+            requires:
+              - test_source
 
       - ruff:
           matrix:
@@ -273,18 +275,6 @@ workflows:
     # Test and publish on new git version tags
     # This requires its own workflow to successfully trigger the test and build
     jobs:
-      - build_distribution:
-          matrix:
-            parameters:
-              version:
-                - "3.14"
-          filters:
-            branches:
-              ignore: /.*/
-            # only act on version tags
-            tags:
-              only: /^v[0-9]+(\.[0-9]+)*$/
-
       - test_source:
           matrix:
             parameters:
@@ -300,6 +290,20 @@ workflows:
             # only act on version tags
             tags:
               only: /^v[0-9]+(\.[0-9]+)*$/
+
+      - build_distribution:
+          matrix:
+            parameters:
+              version:
+                - "3.14"
+          filters:
+            branches:
+              ignore: /.*/
+            # only act on version tags
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*$/
+            requires:
+              - test_source
 
       - ruff:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
             .wheeltest/bin/python -m pip install "$WHEEL"[tests]
             TEST_PYTHON="$(pwd)/.wheeltest/bin/python"
             rm -rf /tmp/spharpy-wheel-tests
-            cp -r tests /tmp/spharpy-wheel-tests
+            cp -r tests /tmp/spharpy-wheel-tests/tests/
             cd /tmp/spharpy-wheel-tests
             "$TEST_PYTHON" -m pytest .
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ jobs:
             .wheeltest/bin/python -m pip install "$WHEEL"[tests]
             TEST_PYTHON="$(pwd)/.wheeltest/bin/python"
             rm -rf /tmp/spharpy-wheel-tests
+            mkdir -p /tmp/spharpy-wheel-tests/tests
             cp -r tests /tmp/spharpy-wheel-tests/tests/
             cd /tmp/spharpy-wheel-tests
             "$TEST_PYTHON" -m pytest .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,9 +191,6 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Install System Dependencies
-          command: sudo apt-get update && sudo apt-get install -y libsndfile1
-      - run:
           name: install dependencies
           command: pip install ".[deploy]"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,15 +80,23 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Install wheel in isolated venv and run tests
+          name: Install wheel from workspace in isolated venv
           command: |
             python -m venv .wheeltest
+            # Find the wheel file in the workspace and save it to an environment variable
             WHEEL=$(ls -1 /tmp/workspace/dist/*.whl | head -n 1)
             .wheeltest/bin/python -m pip install "${WHEEL}[tests]"
+            # Create an environment variable for the path to the python executable of the isolated venv
             TEST_PYTHON="$(pwd)/.wheeltest/bin/python"
+      - run:
+          name: Move test files to isolated location
+          command: |
             rm -rf /tmp/spharpy-wheel-tests
             mkdir -p /tmp/spharpy-wheel-tests
             cp -r tests /tmp/spharpy-wheel-tests/
+      - run:
+          name: Run tests against wheel installation (i.e. in isolated environment)
+          command: |
             cd /tmp/spharpy-wheel-tests
             "$TEST_PYTHON" -m pytest tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,40 @@ jobs:
           name: Run tests
           command: pytest
 
+  test_wheel:
+    parameters:
+      version:
+        description: "version tag"
+        default: "latest"
+        type: string
+    executor:
+      name: python-docker
+      version: <<parameters.version>>
+    steps:
+      - checkout
+      - run:
+          name: install dependencies
+          command: pip install ".[tests]"
+      - run:
+          name: Build wheel
+          command: |
+            python -m build --wheel
+      - run:
+          name: Install wheel in isolated venv and remove all source files from the test environment
+          command: |
+            python -m venv .wheeltest
+            WHEEL=$(ls -1 dist/*.whl | head -n 1)
+            .wheeltest/bin/python -m pip install "$WHEEL"
+            .wheeltest/bin/python -c "import pathlib, spharpy; p = pathlib.Path(spharpy.__file__).resolve(); print(p); assert 'site-packages' in str(p), p"
+            TEST_PYTHON="$(pwd)/.wheeltest/bin/python"
+            rm -rf /tmp/spharpy-wheel-tests
+      - run:
+          name: Run tests with wheel installation
+          command: |
+            cp -r tests /tmp/spharpy-wheel-tests
+            cd /tmp/spharpy-wheel-tests
+            "$TEST_PYTHON" -m pytest tests
+
   ruff:
     parameters:
       version:
@@ -178,6 +212,17 @@ workflows:
           requires:
             - build_and_test
 
+      - test_wheel:
+          matrix:
+            parameters:
+              version:
+                - "3.11"
+                - "3.12"
+                - "3.13"
+                - "3.14"
+          requires:
+            - build_and_test
+
       - test_documentation_build:
           matrix:
             parameters:
@@ -201,6 +246,7 @@ workflows:
                 - "3.14"
           requires:
             - build_and_test
+            - test_wheel
 
 
   test_and_publish:
@@ -227,6 +273,23 @@ workflows:
           matrix:
             parameters:
               version:
+                - "3.14"
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              ignore: /.*/
+            # only act on version tags
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*$/
+
+      - test_wheel:
+          matrix:
+            parameters:
+              version:
+                - "3.11"
+                - "3.12"
+                - "3.13"
                 - "3.14"
           requires:
             - build_and_test
@@ -272,6 +335,7 @@ workflows:
                 - "3.14"
           requires:
             - build_and_test
+            - test_wheel
             - ruff
             - test_documentation_build
           filters:


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #309 

### Changes proposed in this pull request:

- Add test against the binary distribution (wheels) to the CircleCI pipeline
- Also re-organized the test pipeline a bit. Built products are now stored in the workspace and passed between runners to avoid duplicate steps.
- Removed commented out installation of system dependencies.


**Note:** tests are expected to fail, since this PR helps to detect issues such as reported in #308, see #309 for further info.