### PR TITLE
Constrain Sphinx version to avoid issues with Sphinx >=9.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ tests = [
 
 ]
 docs = [
-    "sphinx",
+    "sphinx>=8.0.0,<9.0.0",
     "autodocsumm>=0.2.14",
     "pydata-sphinx-theme",
     "sphinx_mdinclude",


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #318

### Changes proposed in this pull request:

- Constrain Sphinx to versions 8.x.x

This constrain can hopefully relaxed after https://github.com/sphinx-doc/sphinx/pull/14391 is merged
