### PR TITLE
Feature/add sh axis property multichannel

### DIFF
--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -63,7 +63,8 @@ def _assert_valid_number_of_sh_channels(shape, sh_axis):
     shape : tuple, int
         Shape of the data array.
     sh_axis : int
-        Axis which stores the spherical harmonic coefficients
+        Specifies which axis of data holds the spherical harmonic coefficients.
+        Negative indexing, i.e., interpreted relative to the end of the array.
 
     Raises
     ------
@@ -98,6 +99,9 @@ def _convert_to_standard_definition(
     channel_convention : str
         Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
         (FuMa is only supported up to 3rd order)
+    sh_axis : int
+        Specifies which axis of data holds the spherical harmonic coefficients.
+        Negative indexing, i.e., interpreted relative to the end of the array.
 
     Returns
     -------
@@ -133,6 +137,9 @@ def _convert_from_standard_definition(
     channel_convention : str
         Channel ordering convention, either ``'ACN'`` or ``'FuMa'``.
         (FuMa is only supported up to 3rd order)
+    sh_axis : int
+        Specifies which axis of data holds the spherical harmonic coefficients.
+        Negative indexing, i.e., interpreted relative to the end of the array.
 
     Returns
     -------
@@ -186,6 +193,9 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
         Domain of data. The default is ``'time'``
     comment : str
         A comment related to `data`. The default is ``None``.
+    sh_caxis : int
+        Specifies which axis of data holds the spherical harmonic coefficients.
+        Negative indexing, i.e., interpreted relative to the end of the array.
 
     """
 
@@ -270,6 +280,10 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
     is_complex : bool, optional
         A flag which indicates if the time data are real or complex-valued.
         The default is ``False``.
+    sh_caxis : int
+        Specifies which axis of data holds the spherical harmonic coefficients.
+        Negative indexing, i.e., interpreted relative to the end of the array.
+        default is second last axis (-2).
     """
 
     def __init__(self, data, times, basis_type, normalization,
@@ -322,6 +336,10 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         is_complex : bool, optional
             A flag which indicates if the time data are real or complex-valued.
             The default is ``False``.
+        sh_caxis : int
+            Specifies which axis of data holds the spherical harmonic
+            coefficients. Negative indexing, i.e., interpreted relative to the
+            end of the array. The default is second last axis (-2).
         """
         return cls(data, times,
                    basis_type=sh_definition.basis_type,
@@ -388,6 +406,10 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
         and ``False`` for real `basis_type`.
     comment : str
         A comment related to `data`. The default is ``""``.
+    sh_caxis : int
+        Specifies which axis of data holds the spherical harmonic coefficients.
+        Negative indexing, i.e., interpreted relative to the end of the array.
+        The default is second last axis (-2).
     """
 
     def __init__(self, data, frequencies, basis_type, normalization,
@@ -430,6 +452,10 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
             the size of the last dimension of `data`, i.e., ``data.shape[-1]``.
         comment : str
             A comment related to `data`. The default is ``None``.
+        sh_caxis : int
+            Specifies which axis of data holds the spherical harmonic
+            coefficients. Negative indexing, i.e., interpreted relative to the
+            end of the array. The default is second last axis (-2).
         """
         return cls(data, frequencies,
                    basis_type=sh_definition.basis_type,
@@ -520,6 +546,10 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         Specifies if the underlying time domain data are complex
         or real-valued. If ``True`` and `domain` is ``'time'``, the
         input data will be cast to complex. The default is ``False``.
+    sh_caxis : int
+        Specifies which axis of data holds the spherical harmonic coefficients.
+        Negative indexing, i.e., interpreted relative to the end of the array.
+        The default is second last axis (-2).
 
     References
     ----------
@@ -599,6 +629,10 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
             Specifies if the underlying time domain data are complex
             or real-valued. If ``True`` and `domain` is ``'time'``, the
             input data will be cast to complex. The default is ``False``.
+        sh_caxis : int
+            Specifies which axis of data holds the spherical harmonic
+            coefficients. Negative indexing, i.e., interpreted relative to the
+            end of the array. The default is second last axis (-2).
         """
         return cls(data, sampling_rate,
                    basis_type=sh_definition.basis_type,

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -299,7 +299,7 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
 
         if sh_caxis > 0:
-            raise AttributeError("sh_caxis has to be a negative integer.")
+            raise ValueError("sh_caxis has to be a negative integer.")
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
@@ -422,7 +422,7 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
         _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
 
         if sh_caxis > 0:
-            raise AttributeError("sh_caxis has to be a negative integer.")
+            raise ValueError("sh_caxis has to be a negative integer.")
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
@@ -586,7 +586,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
 
         if sh_caxis > 0:
-            raise AttributeError("sh_caxis has to be a negative integer.")
+            raise ValueError("sh_caxis has to be a negative integer.")
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -194,8 +194,9 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
     comment : str
         A comment related to `data`. The default is ``None``.
     sh_caxis : int
-        Specifies which axis of data holds the spherical harmonic coefficients.
-        Negative indexing, i.e., interpreted relative to the end of the array.
+        Specifies which channel axis of data holds the spherical harmonic
+        coefficients. Negative indexing, i.e., interpreted relative to the end
+        of the array.
 
     """
 
@@ -281,14 +282,14 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         A flag which indicates if the time data are real or complex-valued.
         The default is ``False``.
     sh_caxis : int
-        Specifies which axis of data holds the spherical harmonic coefficients.
-        Negative indexing, i.e., interpreted relative to the end of the array.
-        default is second last axis (-2).
+        Specifies which channel axis of data holds the spherical harmonic
+        coefficients. Negative indexing, i.e., interpreted relative to the end
+        of the array. The default is -1.
     """
 
     def __init__(self, data, times, basis_type, normalization,
                  channel_convention, condon_shortley, comment="",
-                 is_complex=False, sh_caxis=-2):
+                 is_complex=False, sh_caxis=-1):
 
         if not is_complex and basis_type == 'complex':
             raise ValueError(
@@ -296,7 +297,7 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
                 "complex time data. Set is_complex=True.")
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
+        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
 
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
@@ -311,7 +312,7 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
     @classmethod
     def from_definition(
             cls, sh_definition, data, times, comment="", is_complex=False,
-            sh_caxis=-2):
+            sh_caxis=-1):
         r"""
         Create a SphericalHarmonicTimeData class object from
         SphericalHarmonicDefinition object, data, and times.
@@ -342,7 +343,7 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         sh_caxis : int
             Specifies which axis of data holds the spherical harmonic
             coefficients. Negative indexing, i.e., interpreted relative to the
-            end of the array. The default is second last axis (-2).
+            end of the array. The default is second last axis (-1).
         """
         return cls(data, times,
                    basis_type=sh_definition.basis_type,
@@ -362,7 +363,7 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
     def time(self, value):
         """Return or set the time data."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
+        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)
@@ -412,14 +413,14 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
     sh_caxis : int
         Specifies which axis of data holds the spherical harmonic coefficients.
         Negative indexing, i.e., interpreted relative to the end of the array.
-        The default is second last axis (-2).
+        The default is -1.
     """
 
     def __init__(self, data, frequencies, basis_type, normalization,
-                 channel_convention, condon_shortley, comment="", sh_caxis=-2):
+                 channel_convention, condon_shortley, comment="", sh_caxis=-1):
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
+        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
 
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
@@ -433,7 +434,7 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
 
     @classmethod
     def from_definition(
-            cls, sh_definition, data, frequencies, comment="", sh_caxis=-2):
+            cls, sh_definition, data, frequencies, comment="", sh_caxis=-1):
         r"""
         Create a SphericalHarmonicFrequencyData class object from
         SphericalHarmonicDefinition object, data, and frequencies
@@ -461,7 +462,7 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
         sh_caxis : int
             Specifies which axis of data holds the spherical harmonic
             coefficients. Negative indexing, i.e., interpreted relative to the
-            end of the array. The default is second last axis (-2).
+            end of the array. The default is -1.
         """
         return cls(data, frequencies,
                    basis_type=sh_definition.basis_type,
@@ -476,13 +477,13 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
         return _convert_from_standard_definition(FrequencyData.freq.fget(self),
                                                  self.normalization,
                                                  self.channel_convention,
-                                                 self._sh_caxis)
+                                                 self._sh_caxis-1)
 
     @freq.setter
     def freq(self, value):
         """Return or set the data in the frequency domain."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
+        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)
@@ -555,7 +556,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     sh_caxis : int
         Specifies which axis of data holds the spherical harmonic coefficients.
         Negative indexing, i.e., interpreted relative to the end of the array.
-        The default is second last axis (-2).
+        The default is -1.
 
     References
     ----------
@@ -580,10 +581,10 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
                  fft_norm='none',
                  comment="",
                  is_complex=False,
-                 sh_caxis=-2):
+                 sh_caxis=-1):
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
+        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
 
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
@@ -599,7 +600,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     @classmethod
     def from_definition(
             cls, sh_definition, data, sampling_rate, domain='time',
-            fft_norm='none', comment="", is_complex=False, sh_caxis=-2):
+            fft_norm='none', comment="", is_complex=False, sh_caxis=-1):
         r"""
         Create a SphericalHarmonicSignal class object from
         SphericalHarmonicDefinition object, data, and sampling
@@ -641,7 +642,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         sh_caxis : int
             Specifies which axis of data holds the spherical harmonic
             coefficients. Negative indexing, i.e., interpreted relative to the
-            end of the array. The default is second last axis (-2).
+            end of the array. The default is -1.
         """
         return cls(data, sampling_rate,
                    basis_type=sh_definition.basis_type,
@@ -657,13 +658,13 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         return _convert_from_standard_definition(Signal.freq.fget(self),
                                                  self.normalization,
                                                  self.channel_convention,
-                                                 self._sh_caxis)
+                                                 self._sh_caxis-1)
 
     @freq.setter
     def freq(self, value):
         """Return or set the data in the frequency domain."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
+        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)
@@ -676,16 +677,16 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         return _convert_from_standard_definition(Signal.freq_raw.fget(self),
                                                  self.normalization,
                                                  self.channel_convention,
-                                                 self._sh_caxis)
+                                                 self._sh_caxis-1)
 
     @freq_raw.setter
     def freq_raw(self, value):
         """Return or set the frequency domain data without normalization."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
+        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
 
         value = _convert_to_standard_definition(
-            value, self.normalization, self.channel_convention, self._sh_caxis)
+            value, self.normalization, self.channel_convention, self._sh_caxis-1)
 
         Signal.freq_raw.fset(self, value)
 
@@ -695,14 +696,14 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         return _convert_from_standard_definition(Signal.time.fget(self),
                                                  self.normalization,
                                                  self.channel_convention,
-                                                 self._sh_caxis)
+                                                 self._sh_caxis-1)
 
     @time.setter
     def time(self, value):
         """Return or set the time data."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
+        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
 
         value = _convert_to_standard_definition(
-            value, self.normalization, self.channel_convention, self._sh_caxis)
+            value, self.normalization, self.channel_convention, self._sh_caxis-1)
         Signal.time.fset(self, value)

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -55,13 +55,15 @@ def _atleast_3d_first_dimension(data):
     return data[np.newaxis, ...] if data.ndim < 3 else data
 
 
-def _assert_valid_number_of_sh_channels(shape):
+def _assert_valid_number_of_sh_channels(shape, sh_axis):
     """Check if the channel shape matches an integer spherical harmonic order.
 
     Parameters
     ----------
     shape : tuple, int
         Shape of the data array.
+    sh_axis : int
+        Axis which stores the spherical harmonic coefficients
 
     Raises
     ------
@@ -70,7 +72,7 @@ def _assert_valid_number_of_sh_channels(shape):
         (n_max + 1)^2 for an integer n_max.
     """
 
-    sh_channels = shape[-2]
+    sh_channels = shape[sh_axis]
     n_max = np.sqrt(sh_channels)-1
     if n_max - int(n_max) != 0:
         raise ValueError(
@@ -186,7 +188,7 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
     """
 
     def __init__(self, basis_type, normalization, channel_convention,
-                 condon_shortley):
+                 condon_shortley, sh_caxis):
 
         _SphericalHarmonicBase.__init__(
             self,
@@ -195,10 +197,17 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
             channel_convention,
             condon_shortley)
 
+        self._sh_caxis = sh_caxis
+
     @property
     def n_max(self):
         """Get or set the spherical harmonic order."""
         return int(np.sqrt(self.cshape[-1])-1)
+
+    @property
+    def sh_caxis(self):
+        """Get the spherical harmonic axis"""
+        return self._sh_caxis
 
     @_SphericalHarmonicBase.basis_type.setter
     def basis_type(self, value):
@@ -263,7 +272,7 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
 
     def __init__(self, data, times, basis_type, normalization,
                  channel_convention, condon_shortley, comment="",
-                 is_complex=False):
+                 is_complex=False, sh_caxis=-2):
 
         if not is_complex and basis_type == 'complex':
             raise ValueError(
@@ -271,18 +280,19 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
                 "complex time data. Set is_complex=True.")
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape)
+        _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
-            condon_shortley)
+            condon_shortley, sh_caxis=sh_caxis)
 
         TimeData.__init__(self, data=data, times=times, comment=comment,
                           is_complex=is_complex)
 
     @classmethod
     def from_definition(
-            cls, sh_definition, data, times, comment="", is_complex=False):
+            cls, sh_definition, data, times, comment="", is_complex=False,
+            sh_caxis=-2):
         r"""
         Create a SphericalHarmonicTimeData class object from
         SphericalHarmonicDefinition object, data, and times.
@@ -316,7 +326,7 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
                    normalization=sh_definition.normalization,
                    channel_convention=sh_definition.channel_convention,
                    condon_shortley=sh_definition.condon_shortley,
-                   comment=comment, is_complex=is_complex)
+                   comment=comment, is_complex=is_complex, sh_caxis=sh_caxis)
 
     @property
     def time(self):
@@ -329,7 +339,7 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
     def time(self, value):
         """Return or set the time data."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape)
+        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)
@@ -379,21 +389,21 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
     """
 
     def __init__(self, data, frequencies, basis_type, normalization,
-                 channel_convention, condon_shortley, comment=""):
+                 channel_convention, condon_shortley, comment="", sh_caxis=-2):
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape)
+        _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
-            condon_shortley)
+            condon_shortley, sh_caxis=sh_caxis)
 
         FrequencyData.__init__(self, data=data, frequencies=frequencies,
                                comment=comment)
 
     @classmethod
     def from_definition(
-            cls, sh_definition, data, frequencies, comment=""):
+            cls, sh_definition, data, frequencies, comment="", sh_caxis=-2):
         r"""
         Create a SphericalHarmonicFrequencyData class object from
         SphericalHarmonicDefinition object, data, and frequencies
@@ -424,7 +434,7 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
                    normalization=sh_definition.normalization,
                    channel_convention=sh_definition.channel_convention,
                    condon_shortley=sh_definition.condon_shortley,
-                   comment=comment)
+                   comment=comment, sh_caxis=sh_caxis)
 
     @property
     def freq(self):
@@ -437,7 +447,7 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
     def freq(self, value):
         """Return or set the data in the frequency domain."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape)
+        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)
@@ -530,14 +540,15 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
                  domain='time',
                  fft_norm='none',
                  comment="",
-                 is_complex=False):
+                 is_complex=False,
+                 sh_caxis=-2):
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape)
+        _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
-            condon_shortley)
+            condon_shortley, sh_caxis=sh_caxis)
 
         Signal.__init__(self, data=data, sampling_rate=sampling_rate,
                         n_samples=n_samples, domain=domain, fft_norm=fft_norm,
@@ -546,7 +557,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     @classmethod
     def from_definition(
             cls, sh_definition, data, sampling_rate, domain='time',
-            fft_norm='none', comment="", is_complex=False):
+            fft_norm='none', comment="", is_complex=False, sh_caxis=-2):
         r"""
         Create a SphericalHarmonicSignal class object from
         SphericalHarmonicDefinition object, data, and sampling
@@ -592,7 +603,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
                    channel_convention=sh_definition.channel_convention,
                    condon_shortley=sh_definition.condon_shortley,
                    domain=domain, fft_norm=fft_norm,
-                   comment=comment, is_complex=is_complex)
+                   comment=comment, is_complex=is_complex, sh_caxis=sh_caxis)
 
     @property
     def freq(self):
@@ -605,7 +616,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     def freq(self, value):
         """Return or set the data in the frequency domain."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape)
+        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)
@@ -623,7 +634,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     def freq_raw(self, value):
         """Return or set the frequency domain data without normalization."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape)
+        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)
@@ -641,7 +652,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     def time(self, value):
         """Return or set the time data."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape)
+        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -298,6 +298,9 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         data = _atleast_3d_first_dimension(data)
         _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
 
+        if sh_caxis > 0:
+            raise AttributeError("sh_caxis has to be a negative integer.")
+
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
             condon_shortley, sh_caxis=sh_caxis)
@@ -417,6 +420,9 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
 
         data = _atleast_3d_first_dimension(data)
         _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
+
+        if sh_caxis > 0:
+            raise AttributeError("sh_caxis has to be a negative integer.")
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
@@ -578,6 +584,9 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
 
         data = _atleast_3d_first_dimension(data)
         _assert_valid_number_of_sh_channels(data.shape, sh_caxis)
+
+        if sh_caxis > 0:
+            raise AttributeError("sh_caxis has to be a negative integer.")
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -301,6 +301,9 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
 
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
+        if abs(sh_caxis) >= data.ndim:
+            raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
+                             f"dimensions of data ({data.ndim})")
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
@@ -424,6 +427,9 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
 
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
+        if abs(sh_caxis) >= data.ndim:
+            raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
+                             f"dimensions of data ({data.ndim})")
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
@@ -588,6 +594,9 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
 
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
+        if abs(sh_caxis) >= data.ndim:
+            raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
+                             f"dimensions of data ({data.ndim})")
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -83,7 +83,8 @@ def _assert_valid_number_of_sh_channels(shape, sh_axis):
 def _convert_to_standard_definition(
         data,
         normalization,
-        channel_convention):
+        channel_convention,
+        sh_axis=-2):
     """Convert data to the standard spherical harmonic definition.
 
     Parameters
@@ -106,10 +107,10 @@ def _convert_to_standard_definition(
 
     data = renormalize(
         data, channel_convention, normalization,
-        "N3D", axis=-2)
+        "N3D", axis=sh_axis)
 
     data = change_channel_convention(
-        data, channel_convention, "ACN", axis=-2)
+        data, channel_convention, "ACN", axis=sh_axis)
 
     return data
 
@@ -117,7 +118,8 @@ def _convert_to_standard_definition(
 def _convert_from_standard_definition(
         data,
         normalization,
-        channel_convention):
+        channel_convention,
+        sh_axis=-2):
     """Convert data from standard definition to the desired one.
 
     Parameters
@@ -139,10 +141,10 @@ def _convert_from_standard_definition(
     """
 
     data = renormalize(
-        data, "ACN", "N3D", normalization, axis=-2)
+        data, "ACN", "N3D", normalization, axis=sh_axis)
 
     data = change_channel_convention(
-        data, "ACN", channel_convention, axis=-2)
+        data, "ACN", channel_convention, axis=sh_axis)
 
     return data
 
@@ -441,7 +443,8 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
         """Return or set the data in the frequency domain."""
         return _convert_from_standard_definition(FrequencyData.freq.fget(self),
                                                  self.normalization,
-                                                 self.channel_convention)
+                                                 self.channel_convention,
+                                                 self._sh_caxis)
 
     @freq.setter
     def freq(self, value):
@@ -610,7 +613,8 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         """Return or set the data in the frequency domain."""
         return _convert_from_standard_definition(Signal.freq.fget(self),
                                                  self.normalization,
-                                                 self.channel_convention)
+                                                 self.channel_convention,
+                                                 self._sh_caxis)
 
     @freq.setter
     def freq(self, value):
@@ -628,7 +632,8 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         """Return or set the frequency domain data without normalization."""
         return _convert_from_standard_definition(Signal.freq_raw.fget(self),
                                                  self.normalization,
-                                                 self.channel_convention)
+                                                 self.channel_convention,
+                                                 self._sh_caxis)
 
     @freq_raw.setter
     def freq_raw(self, value):
@@ -637,7 +642,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
 
         value = _convert_to_standard_definition(
-            value, self.normalization, self.channel_convention)
+            value, self.normalization, self.channel_convention, self._sh_caxis)
 
         Signal.freq_raw.fset(self, value)
 
@@ -646,7 +651,8 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         """Return or set the time data."""
         return _convert_from_standard_definition(Signal.time.fget(self),
                                                  self.normalization,
-                                                 self.channel_convention)
+                                                 self.channel_convention,
+                                                 self._sh_caxis)
 
     @time.setter
     def time(self, value):
@@ -655,5 +661,5 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis)
 
         value = _convert_to_standard_definition(
-            value, self.normalization, self.channel_convention)
+            value, self.normalization, self.channel_convention, self._sh_caxis)
         Signal.time.fset(self, value)

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -294,16 +294,16 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         if not is_complex and basis_type == 'complex':
             raise ValueError(
                 "Complex spherical harmonic basis requires "
-                "complex time data. Set is_complex=True.")
-
-        data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
+                "complex time data. Set is_complex=True.")        
 
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
         if abs(sh_caxis) >= data.ndim:
             raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
                              f"dimensions of data ({data.ndim})")
+
+        data = _atleast_3d_first_dimension(data)
+        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
@@ -422,14 +422,14 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
     def __init__(self, data, frequencies, basis_type, normalization,
                  channel_convention, condon_shortley, comment="", sh_caxis=-1):
 
-        data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
-
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
         if abs(sh_caxis) >= data.ndim:
             raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
                              f"dimensions of data ({data.ndim})")
+
+        data = _atleast_3d_first_dimension(data)
+        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
@@ -589,14 +589,14 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
                  is_complex=False,
                  sh_caxis=-1):
 
-        data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
-
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
         if abs(sh_caxis) >= data.ndim:
             raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
                              f"dimensions of data ({data.ndim})")
+
+        data = _atleast_3d_first_dimension(data)
+        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
@@ -695,7 +695,8 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
 
         value = _convert_to_standard_definition(
-            value, self.normalization, self.channel_convention, self._sh_caxis-1)
+            value, self.normalization, self.channel_convention,
+            self._sh_caxis-1)
 
         Signal.freq_raw.fset(self, value)
 
@@ -714,5 +715,6 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
 
         value = _convert_to_standard_definition(
-            value, self.normalization, self.channel_convention, self._sh_caxis-1)
+            value, self.normalization, self.channel_convention,
+            self._sh_caxis-1)
         Signal.time.fset(self, value)

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -193,18 +193,18 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
         Domain of data. The default is ``'time'``
     comment : str
         A comment related to `data`. The default is ``None``.
-    sh_caxis : int
+    caxis_spherical_harmonics : int
         Specifies which channel axis of data holds the spherical harmonic
         coefficients. Must be an integer smaller than or equal to -1.
         The default -1 refers to the last channel axis; a value of -2
         would refer to the second last channel axis. See
-        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
         for more details.
 
     """
 
     def __init__(self, basis_type, normalization, channel_convention,
-                 condon_shortley, sh_caxis):
+                 condon_shortley, caxis_spherical_harmonics):
 
         _SphericalHarmonicBase.__init__(
             self,
@@ -213,7 +213,7 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
             channel_convention,
             condon_shortley)
 
-        self._sh_caxis = sh_caxis
+        self._caxis_spherical_harmonics = caxis_spherical_harmonics
 
     @property
     def n_max(self):
@@ -221,9 +221,9 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
         return int(np.sqrt(self.cshape[-1])-1)
 
     @property
-    def sh_caxis(self):
+    def caxis_spherical_harmonics(self):
         """Get the spherical harmonic axis"""
-        return self._sh_caxis
+        return self._caxis_spherical_harmonics
 
     @_SphericalHarmonicBase.basis_type.setter
     def basis_type(self, value):
@@ -254,14 +254,14 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         Raw data in the time domain. The data should have at least 2
         dimensions, with the last dimension representing the time domain
         samples and the second to last the spherical harmonic coefficients. If
-        the raw data have more then 3 dimensions `sh_caxis` defines the
-        axis holding the spherical harmonic coefficients. The default is
-        -1 (second to last channel axis). Accordingly, the default data
-        shape follows the 'C' memory layout, e.g. data of
+        the raw data have more then 3 dimensions `caxis_spherical_harmonics`
+        defines the axis holding the spherical harmonic coefficients. The
+        default is -1 (second to last channel axis). Accordingly, the default
+        data shape follows the 'C' memory layout, e.g. data of
         ``shape = (1, 4, 1024)`` has 1 channel with 4 spherical harmonic
-        coefficients with 1024 samples each, and `sh_caxis` = -1. The data
-        can be ``int``, ``float`` or ``complex``. Data of type ``int`` is
-        converted to ``float``.
+        coefficients with 1024 samples each, and
+        `caxis_spherical_harmonics` = -1. The data can be ``int``, ``float``
+        or ``complex``. Data of type ``int`` is converted to ``float``.
     times : array, double
         Times in seconds at which the data is sampled. The number of times
         must match the size of the last dimension of `data`, i.e.,
@@ -286,36 +286,36 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
     is_complex : bool, optional
         A flag which indicates if the time data are real or complex-valued.
         The default is ``False``.
-    sh_caxis : int
+    caxis_spherical_harmonics : int
         Specifies which channel axis of data holds the spherical harmonic
         coefficients. Must be an integer smaller than or equal to -1.
         The default -1 refers to the last channel axis; a value of -2
         would refer to the second last channel axis. See
-        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
         for more details.
     """
 
     def __init__(self, data, times, basis_type, normalization,
                  channel_convention, condon_shortley, comment="",
-                 is_complex=False, sh_caxis=-1):
+                 is_complex=False, caxis_spherical_harmonics=-1):
 
         if not is_complex and basis_type == 'complex':
             raise ValueError(
                 "Complex spherical harmonic basis requires "
                 "complex time data. Set is_complex=True.")
-
-        if sh_caxis > 0:
-            raise ValueError("sh_caxis has to be a negative integer.")
-        if abs(sh_caxis) > data.ndim:
-            raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
-                             f"dimensions of data ({data.ndim})")
+        if abs(caxis_spherical_harmonics) > data.ndim:
+            raise ValueError(
+                    f"caxis_spherical_harmonics ({caxis_spherical_harmonics}) "
+                    f"exceeds the number of dimensions of data ({data.ndim})")
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
+        _assert_valid_number_of_sh_channels(data.shape,
+                                            caxis_spherical_harmonics-1)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
-            condon_shortley, sh_caxis=sh_caxis)
+            condon_shortley,
+            caxis_spherical_harmonics=caxis_spherical_harmonics)
 
         TimeData.__init__(self, data=data, times=times, comment=comment,
                           is_complex=is_complex)
@@ -323,7 +323,7 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
     @classmethod
     def from_definition(
             cls, sh_definition, data, times, comment="", is_complex=False,
-            sh_caxis=-1):
+            caxis_spherical_harmonics=-1):
         r"""
         Create a SphericalHarmonicTimeData class object from
         SphericalHarmonicDefinition object, data, and times.
@@ -335,15 +335,16 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         data : array, double
             Raw data in the time domain. The data should have at least 2
             dimensions, with the last dimension representing the time domain
-            samples and the second to last the spherical harmonic coefficients. If
-            the raw data have more then 3 dimensions `sh_caxis` defines the
-            axis holding the spherical harmonic coefficients. The default is
-            -1 (second to last channel axis). Accordingly, the default data
-            shape follows the 'C' memory layout, e.g. data of
-            ``shape = (1, 4, 1024)`` has 1 channel with 4 spherical harmonic
-            coefficients with 1024 samples each, and `sh_caxis` = -1. The data
-            can be ``int``, ``float`` or ``complex``. Data of type ``int`` is
-            converted to ``float``.
+            samples and the second to last the spherical harmonic coefficients.
+            If the raw data have more then 3 dimensions
+            `caxis_spherical_harmonics` defines the axis holding the spherical
+            harmonic coefficients. The default is -1 (second to last channel
+            axis). Accordingly, the default data shape follows the 'C' memory
+            layout, e.g. data of ``shape = (1, 4, 1024)`` has 1 channel with 4
+            spherical harmonic coefficients with 1024 samples each, and
+            `caxis_spherical_harmonics` = -1. The data can be ``int``,
+            ``float`` or ``complex``. Data of type ``int`` is converted to
+            ``float``.
         times : array, double
             Times in seconds at which the data is sampled. The number of times
             must match the size of the last dimension of `data`, i.e.,
@@ -363,7 +364,8 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
                    normalization=sh_definition.normalization,
                    channel_convention=sh_definition.channel_convention,
                    condon_shortley=sh_definition.condon_shortley,
-                   comment=comment, is_complex=is_complex, sh_caxis=sh_caxis)
+                   comment=comment, is_complex=is_complex,
+                   caxis_spherical_harmonics=caxis_spherical_harmonics)
 
     @property
     def time(self):
@@ -376,7 +378,8 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
     def time(self, value):
         """Return or set the time data."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
+        _assert_valid_number_of_sh_channels(value.shape,
+                                            self._caxis_spherical_harmonics-1)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)
@@ -398,14 +401,14 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
         Raw data in the frequency domain. The data should have at least 2
         dimensions, with the last dimension representing the frequency domain
         bins and the second to last the spherical harmonic coefficients. If
-        the raw data have more then 3 dimensions `sh_caxis` defines the
-        axis holding the spherical harmonic coefficients. The default is
-        -1 (second to last channel axis). Accordingly, the default data
-        shape follows the 'C' memory layout, e.g. data of
+        the raw data have more then 3 dimensions `caxis_spherical_harmonics`
+        defines the axis holding the spherical harmonic coefficients. The
+        default is -1 (second to last channel axis). Accordingly, the default
+        data shape follows the 'C' memory layout, e.g. data of
         ``shape = (1, 4, 1024)`` has 1 channel with 4 spherical harmonic
-        coefficients with 1024 frequency bins each, and `sh_caxis` = -1. The
-        data can be ``int``, ``float`` or ``complex``. Data of type ``int`` is
-        converted to ``float``.
+        coefficients with 1024 frequency bins each, and
+        `caxis_spherical_harmonics` = -1. The data can be ``int``, ``float``
+        or ``complex``. Data of type ``int`` is converted to ``float``.
     frequencies : array, double
         Frequencies of the data in Hz. The number of frequencies must match
         the size of the last dimension of `data`, i.e., ``data.shape[-1]``.
@@ -425,37 +428,40 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
         and ``False`` for real `basis_type`.
     comment : str
         A comment related to `data`. The default is ``""``.
-    sh_caxis : int
+    caxis_spherical_harmonics : int
         Specifies which channel axis of data holds the spherical harmonic
         coefficients. Must be an integer smaller than or equal to -1.
         The default -1 refers to the last channel axis; a value of -2
         would refer to the second last channel axis. See
-        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
         for more details.
     """
 
     def __init__(self, data, frequencies, basis_type, normalization,
-                 channel_convention, condon_shortley, comment="", sh_caxis=-1):
+                 channel_convention, condon_shortley, comment="",
+                 caxis_spherical_harmonics=-1):
 
-        if sh_caxis > 0:
-            raise ValueError("sh_caxis has to be a negative integer.")
-        if abs(sh_caxis) > data.ndim:
-            raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
-                             f"dimensions of data ({data.ndim})")
+        if abs(caxis_spherical_harmonics) > data.ndim:
+            raise ValueError(
+                    f"caxis_spherical_harmonics ({caxis_spherical_harmonics}) "
+                    f"exceeds the number of dimensions of data ({data.ndim})")
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
+        _assert_valid_number_of_sh_channels(data.shape,
+                                            caxis_spherical_harmonics-1)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
-            condon_shortley, sh_caxis=sh_caxis)
+            condon_shortley,
+            caxis_spherical_harmonics=caxis_spherical_harmonics)
 
         FrequencyData.__init__(self, data=data, frequencies=frequencies,
                                comment=comment)
 
     @classmethod
     def from_definition(
-            cls, sh_definition, data, frequencies, comment="", sh_caxis=-1):
+            cls, sh_definition, data, frequencies, comment="",
+            caxis_spherical_harmonics=-1):
         r"""
         Create a SphericalHarmonicFrequencyData class object from
         SphericalHarmonicDefinition object, data, and frequencies
@@ -467,27 +473,28 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
             The spherical harmonic definition.
         data : ndarray, double
             Raw data in the frequency domain. The data should have at least 2
-            dimensions, with the last dimension representing the frequency domain
-            bins and the second to last the spherical harmonic coefficients. If
-            the raw data have more then 3 dimensions `sh_caxis` defines the
-            axis holding the spherical harmonic coefficients. The default is
-            -1 (second to last channel axis). Accordingly, the default data
-            shape follows the 'C' memory layout, e.g. data of
-            ``shape = (1, 4, 1024)`` has 1 channel with 4 spherical harmonic
-            coefficients with 1024 frequency bins each, and `sh_caxis` = -1. The
-            data can be ``int``, ``float`` or ``complex``. Data of type ``int`` is
-            converted to ``float``.
+            dimensions, with the last dimension representing the frequency
+            domain bins and the second to last the spherical harmonic
+            coefficients. If the raw data have more then 3 dimensions
+            `caxis_spherical_harmonics` defines the axis holding the spherical
+            harmonic coefficients. The default is -1 (second to last channel
+            axis). Accordingly, the default data shape follows the 'C' memory
+            layout, e.g. data of ``shape = (1, 4, 1024)`` has 1 channel with 4
+            spherical harmonic coefficients with 1024 frequency bins each, and
+            `caxis_spherical_harmonics` = -1. The data can be ``int``,
+            ``float`` or ``complex``. Data of type ``int`` is converted to
+            ``float``.
         frequencies : array, double
             Frequencies of the data in Hz. The number of frequencies must match
             the size of the last dimension of `data`, i.e., ``data.shape[-1]``.
         comment : str
             A comment related to `data`. The default is ``None``.
-        sh_caxis : int
+        caxis_spherical_harmonics : int
             Specifies which channel axis of data holds the spherical harmonic
             coefficients. Must be an integer smaller than or equal to -1.
             The default -1 refers to the last channel axis; a value of -2
             would refer to the second last channel axis. See
-            https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+            https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
             for more details.
         """
         return cls(data, frequencies,
@@ -495,21 +502,24 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
                    normalization=sh_definition.normalization,
                    channel_convention=sh_definition.channel_convention,
                    condon_shortley=sh_definition.condon_shortley,
-                   comment=comment, sh_caxis=sh_caxis)
+                   comment=comment,
+                   caxis_spherical_harmonics=caxis_spherical_harmonics)
 
     @property
     def freq(self):
         """Return or set the data in the frequency domain."""
-        return _convert_from_standard_definition(FrequencyData.freq.fget(self),
-                                                 self.normalization,
-                                                 self.channel_convention,
-                                                 self._sh_caxis-1)
+        return _convert_from_standard_definition(
+                    FrequencyData.freq.fget(self),
+                    self.normalization,
+                    self.channel_convention,
+                    self._caxis_spherical_harmonics-1)
 
     @freq.setter
     def freq(self, value):
         """Return or set the data in the frequency domain."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
+        _assert_valid_number_of_sh_channels(value.shape,
+                                            self._caxis_spherical_harmonics-1)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)
@@ -538,15 +548,16 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         the last dimension representing the time domain
         samples/frequency domain bins and the second to last the spherical
         harmonic coefficients. If the raw data have more then 3 dimensions
-        `sh_caxis` defines the axis holding the spherical harmonic
-        coefficients. The default is -1 (second to last channel axis).
+        `caxis_spherical_harmonics` defines the axis holding the spherical
+        harmonic coefficients. The default is -1 (second to last channel axis).
         Accordingly, the default data shape follows the 'C' memory layout,
         e.g. data of ``shape = (1, 4, 1024)`` has 1 channel with 4 spherical
         harmonic coefficients with 1024 samples or frequency bins each, and
-        `sh_caxis` = -1. The data can be ``int``, ``float`` or ``complex``.
-        Data of type ``int`` is converted to ``float``. Frequency is converted
-        to ``complex`` and must be provided as single sided spectra, i.e., for
-        all frequencies between 0 Hz and half the sampling rate.
+        `caxis_spherical_harmonics` = -1. The data can be ``int``, ``float``
+        or ``complex``. Data of type ``int`` is converted to ``float``.
+        Frequency is converted to ``complex`` and must be provided as single
+        sided spectra, i.e., for all frequencies between 0 Hz and half the
+        sampling rate.
     sampling_rate : double
         Sampling rate in Hz
     basis_type : str
@@ -581,12 +592,12 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         Specifies if the underlying time domain data are complex
         or real-valued. If ``True`` and `domain` is ``'time'``, the
         input data will be cast to complex. The default is ``False``.
-    sh_caxis : int
+    caxis_spherical_harmonics : int
         Specifies which channel axis of data holds the spherical harmonic
         coefficients. Must be an integer smaller than or equal to -1.
         The default -1 refers to the last channel axis; a value of -2
         would refer to the second last channel axis. See
-        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
         for more details.
 
     References
@@ -612,20 +623,21 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
                  fft_norm='none',
                  comment="",
                  is_complex=False,
-                 sh_caxis=-1):
+                 caxis_spherical_harmonics=-1):
 
-        if sh_caxis > 0:
-            raise ValueError("sh_caxis has to be a negative integer.")
-        if abs(sh_caxis) > data.ndim:
-            raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
-                             f"dimensions of data ({data.ndim})")
+        if abs(caxis_spherical_harmonics) > data.ndim:
+            raise ValueError(
+                f"caxis_spherical_harmonics ({caxis_spherical_harmonics}) "
+                f"exceeds the number of dimensions of data ({data.ndim})")
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape, sh_caxis-1)
+        _assert_valid_number_of_sh_channels(data.shape,
+                                            caxis_spherical_harmonics-1)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
-            condon_shortley, sh_caxis=sh_caxis)
+            condon_shortley,
+            caxis_spherical_harmonics=caxis_spherical_harmonics)
 
         Signal.__init__(self, data=data, sampling_rate=sampling_rate,
                         n_samples=n_samples, domain=domain, fft_norm=fft_norm,
@@ -634,7 +646,8 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     @classmethod
     def from_definition(
             cls, sh_definition, data, sampling_rate, domain='time',
-            fft_norm='none', comment="", is_complex=False, sh_caxis=-1):
+            fft_norm='none', comment="", is_complex=False,
+            caxis_spherical_harmonics=-1):
         r"""
         Create a SphericalHarmonicSignal class object from
         SphericalHarmonicDefinition object, data, and sampling
@@ -645,18 +658,21 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         sh_definition : SphericalHarmonicDefinition
             The spherical harmonic definition.
         data : ndarray, double
-            Raw data of the spherical harmonic signal in the time or
+            Raw data of the spherical harmonics signal in the time or
             frequency domain. The data should have at least 2 dimensions, with
             the last dimension representing the time domain
-            samples/frequency domain bins, the second to last the spherical
-            harmonic coefficients, and any leading dimensions representing
-            optional channels. Accordingly, the data should follow the 'C'
-            memory layout, e.g. data of ``shape = (1, 4, 1024)`` has 1 channel
-            with 4 spherical harmonic coefficients with 1024 samples or
-            frequency bins each. Time data is converted to ``float``.
-            Frequency is converted to ``complex`` and must be provided as
-            single sided spectra, i.e., for all frequencies between 0 Hz and
-            half the sampling rate.
+            samples/frequency domain bins and the second to last the spherical
+            harmonic coefficients. If the raw data have more then 3 dimensions
+            `caxis_spherical_harmonics` defines the axis holding the spherical
+            harmonic coefficients. The default is -1 (second to last channel
+            axis). Accordingly, the default data shape follows the 'C' memory
+            layout, e.g. data of ``shape = (1, 4, 1024)`` has 1 channel with 4
+            spherical harmonic coefficients with 1024 samples or frequency
+            bins each, and `caxis_spherical_harmonics` = -1. The data can be
+            ``int``, ``float`` or ``complex``. Data of type ``int`` is
+            converted to ``float``. Frequency is converted to ``complex`` and
+            must be provided as single sided spectra, i.e., for all
+            frequencies between 0 Hz and half the sampling rate.
         sampling_rate : double
             Sampling rate in Hz
         domain : ``'time'``, ``'freq'``, optional
@@ -673,12 +689,12 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
             Specifies if the underlying time domain data are complex
             or real-valued. If ``True`` and `domain` is ``'time'``, the
             input data will be cast to complex. The default is ``False``.
-        sh_caxis : int
+        caxis_spherical_harmonics : int
             Specifies which channel axis of data holds the spherical harmonic
             coefficients. Must be an integer smaller than or equal to -1.
             The default -1 refers to the last channel axis; a value of -2
             would refer to the second last channel axis. See
-            https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+            https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
             for more details.
         """
         return cls(data, sampling_rate,
@@ -687,21 +703,24 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
                    channel_convention=sh_definition.channel_convention,
                    condon_shortley=sh_definition.condon_shortley,
                    domain=domain, fft_norm=fft_norm,
-                   comment=comment, is_complex=is_complex, sh_caxis=sh_caxis)
+                   comment=comment, is_complex=is_complex,
+                   caxis_spherical_harmonics=caxis_spherical_harmonics)
 
     @property
     def freq(self):
         """Return or set the data in the frequency domain."""
-        return _convert_from_standard_definition(Signal.freq.fget(self),
-                                                 self.normalization,
-                                                 self.channel_convention,
-                                                 self._sh_caxis-1)
+        return _convert_from_standard_definition(
+                    Signal.freq.fget(self),
+                    self.normalization,
+                    self.channel_convention,
+                    self._caxis_spherical_harmonics-1)
 
     @freq.setter
     def freq(self, value):
         """Return or set the data in the frequency domain."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
+        _assert_valid_number_of_sh_channels(value.shape,
+                                            self._caxis_spherical_harmonics-1)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)
@@ -711,38 +730,42 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     @property
     def freq_raw(self):
         """Return or set the frequency domain data without normalization."""
-        return _convert_from_standard_definition(Signal.freq_raw.fget(self),
-                                                 self.normalization,
-                                                 self.channel_convention,
-                                                 self._sh_caxis-1)
+        return _convert_from_standard_definition(
+                    Signal.freq_raw.fget(self),
+                    self.normalization,
+                    self.channel_convention,
+                    self._caxis_spherical_harmonics-1)
 
     @freq_raw.setter
     def freq_raw(self, value):
         """Return or set the frequency domain data without normalization."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
+        _assert_valid_number_of_sh_channels(value.shape,
+                                            self._caxis_spherical_harmonics-1)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention,
-            self._sh_caxis-1)
+            self._caxis_spherical_harmonics-1)
 
         Signal.freq_raw.fset(self, value)
 
     @property
     def time(self):
         """Return or set the time data."""
-        return _convert_from_standard_definition(Signal.time.fget(self),
-                                                 self.normalization,
-                                                 self.channel_convention,
-                                                 self._sh_caxis-1)
+        return _convert_from_standard_definition(
+                    Signal.time.fget(self),
+                    self.normalization,
+                    self.channel_convention,
+                    self._caxis_spherical_harmonics-1)
 
     @time.setter
     def time(self, value):
         """Return or set the time data."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape, self._sh_caxis-1)
+        _assert_valid_number_of_sh_channels(value.shape,
+                                            self._caxis_spherical_harmonics-1)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention,
-            self._sh_caxis-1)
+            self._caxis_spherical_harmonics-1)
         Signal.time.fset(self, value)

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -195,8 +195,11 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
         A comment related to `data`. The default is ``None``.
     sh_caxis : int
         Specifies which channel axis of data holds the spherical harmonic
-        coefficients. Negative indexing, i.e., interpreted relative to the end
-        of the array.
+        coefficients. Must be an integer smaller than or equal to -1.
+        The default -1 refers to the last channel axis; a value of -2
+        would refer to the second last channel axis. See
+        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+        for more details.
 
     """
 
@@ -250,13 +253,15 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
     data : array, double
         Raw data in the time domain. The data should have at least 2
         dimensions, with the last dimension representing the time domain
-        samples, the second to last the spherical harmonic coefficients,
-        and any leading dimensions representing optional channels. Accordingly,
-        the data should follow the 'C' memory layout, e.g. data of
+        samples and the second to last the spherical harmonic coefficients. If
+        the raw data have more then 3 dimensions `sh_caxis` defines the
+        axis holding the spherical harmonic coefficients. The default is
+        -1 (second to last channel axis). Accordingly, the default data
+        shape follows the 'C' memory layout, e.g. data of
         ``shape = (1, 4, 1024)`` has 1 channel with 4 spherical harmonic
-        coefficients with 1024 samples each. The data can be ``int``,
-        ``float`` or ``complex``. Data of type ``int`` is converted to
-        ``float``.
+        coefficients with 1024 samples each, and `sh_caxis` = -1. The data
+        can be ``int``, ``float`` or ``complex``. Data of type ``int`` is
+        converted to ``float``.
     times : array, double
         Times in seconds at which the data is sampled. The number of times
         must match the size of the last dimension of `data`, i.e.,
@@ -283,8 +288,11 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         The default is ``False``.
     sh_caxis : int
         Specifies which channel axis of data holds the spherical harmonic
-        coefficients. Negative indexing, i.e., interpreted relative to the end
-        of the array. The default is -1.
+        coefficients. Must be an integer smaller than or equal to -1.
+        The default -1 refers to the last channel axis; a value of -2
+        would refer to the second last channel axis. See
+        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+        for more details.
     """
 
     def __init__(self, data, times, basis_type, normalization,
@@ -294,11 +302,11 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         if not is_complex and basis_type == 'complex':
             raise ValueError(
                 "Complex spherical harmonic basis requires "
-                "complex time data. Set is_complex=True.")        
+                "complex time data. Set is_complex=True.")
 
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
-        if abs(sh_caxis) >= data.ndim:
+        if abs(sh_caxis) > data.ndim:
             raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
                              f"dimensions of data ({data.ndim})")
 
@@ -327,12 +335,14 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         data : array, double
             Raw data in the time domain. The data should have at least 2
             dimensions, with the last dimension representing the time domain
-            samples, the second to last the spherical harmonic coefficients,
-            and any leading dimensions representing optional channels.
-            Accordingly, the data should follow the 'C' memory layout, e.g.
-            data of ``shape = (1, 4, 1024)`` has 1 channel with 4 spherical
-            harmonic coefficients with 1024 samples each. The data can be
-            ``int``, ``float`` or ``complex``. Data of type ``int`` is
+            samples and the second to last the spherical harmonic coefficients. If
+            the raw data have more then 3 dimensions `sh_caxis` defines the
+            axis holding the spherical harmonic coefficients. The default is
+            -1 (second to last channel axis). Accordingly, the default data
+            shape follows the 'C' memory layout, e.g. data of
+            ``shape = (1, 4, 1024)`` has 1 channel with 4 spherical harmonic
+            coefficients with 1024 samples each, and `sh_caxis` = -1. The data
+            can be ``int``, ``float`` or ``complex``. Data of type ``int`` is
             converted to ``float``.
         times : array, double
             Times in seconds at which the data is sampled. The number of times
@@ -385,15 +395,17 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
     Parameters
     ----------
     data : array, double
-        Raw data in the frequency domain. The data should have at least
-        2 dimensions, with the last dimension representing the frequency domain
-        bins, the second to last the spherical harmonic coefficients,
-        and any leading dimensions representing optional channels. Accordingly,
-        the data should follow the 'C' memory layout, e.g. data of
+        Raw data in the frequency domain. The data should have at least 2
+        dimensions, with the last dimension representing the frequency domain
+        bins and the second to last the spherical harmonic coefficients. If
+        the raw data have more then 3 dimensions `sh_caxis` defines the
+        axis holding the spherical harmonic coefficients. The default is
+        -1 (second to last channel axis). Accordingly, the default data
+        shape follows the 'C' memory layout, e.g. data of
         ``shape = (1, 4, 1024)`` has 1 channel with 4 spherical harmonic
-        coefficients with 1024 frequency bins each. The data can be ``int``,
-        ``float`` or ``complex``. Data of type ``int`` is converted to
-        ``float``.
+        coefficients with 1024 frequency bins each, and `sh_caxis` = -1. The
+        data can be ``int``, ``float`` or ``complex``. Data of type ``int`` is
+        converted to ``float``.
     frequencies : array, double
         Frequencies of the data in Hz. The number of frequencies must match
         the size of the last dimension of `data`, i.e., ``data.shape[-1]``.
@@ -414,9 +426,12 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
     comment : str
         A comment related to `data`. The default is ``""``.
     sh_caxis : int
-        Specifies which axis of data holds the spherical harmonic coefficients.
-        Negative indexing, i.e., interpreted relative to the end of the array.
-        The default is -1.
+        Specifies which channel axis of data holds the spherical harmonic
+        coefficients. Must be an integer smaller than or equal to -1.
+        The default -1 refers to the last channel axis; a value of -2
+        would refer to the second last channel axis. See
+        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+        for more details.
     """
 
     def __init__(self, data, frequencies, basis_type, normalization,
@@ -424,7 +439,7 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
 
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
-        if abs(sh_caxis) >= data.ndim:
+        if abs(sh_caxis) > data.ndim:
             raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
                              f"dimensions of data ({data.ndim})")
 
@@ -451,24 +466,29 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
         sh_definition : SphericalHarmonicDefinition
             The spherical harmonic definition.
         data : ndarray, double
-            Raw data in the frequency domain. The data should have at least
-            2 dimensions, with the last dimension representing the frequency
-            domain bins, the second to last the spherical harmonic
-            coefficients, and any leading dimensions representing optional
-            channels. Accordingly, the data should follow the 'C' memory
-            layout, e.g. data of ``shape = (1, 4, 1024)`` has 1 channel with 4
-            spherical harmonic coefficients with 1024 frequency bins each. The
-            data can be ``int``, ``float`` or ``complex``. Data of type
-            ``int`` is converted to ``float``.
+            Raw data in the frequency domain. The data should have at least 2
+            dimensions, with the last dimension representing the frequency domain
+            bins and the second to last the spherical harmonic coefficients. If
+            the raw data have more then 3 dimensions `sh_caxis` defines the
+            axis holding the spherical harmonic coefficients. The default is
+            -1 (second to last channel axis). Accordingly, the default data
+            shape follows the 'C' memory layout, e.g. data of
+            ``shape = (1, 4, 1024)`` has 1 channel with 4 spherical harmonic
+            coefficients with 1024 frequency bins each, and `sh_caxis` = -1. The
+            data can be ``int``, ``float`` or ``complex``. Data of type ``int`` is
+            converted to ``float``.
         frequencies : array, double
             Frequencies of the data in Hz. The number of frequencies must match
             the size of the last dimension of `data`, i.e., ``data.shape[-1]``.
         comment : str
             A comment related to `data`. The default is ``None``.
         sh_caxis : int
-            Specifies which axis of data holds the spherical harmonic
-            coefficients. Negative indexing, i.e., interpreted relative to the
-            end of the array. The default is -1.
+            Specifies which channel axis of data holds the spherical harmonic
+            coefficients. Must be an integer smaller than or equal to -1.
+            The default -1 refers to the last channel axis; a value of -2
+            would refer to the second last channel axis. See
+            https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+            for more details.
         """
         return cls(data, frequencies,
                    basis_type=sh_definition.basis_type,
@@ -516,15 +536,17 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         Raw data of the spherical harmonics signal in the time or
         frequency domain. The data should have at least 2 dimensions, with
         the last dimension representing the time domain
-        samples/frequency domain bins, the second to last the spherical
-        harmonic coefficients, and any leading dimensions representing
-        optional channels. Accordingly, the data should follow the 'C'
-        memory layout, e.g. data of ``shape = (1, 4, 1024)`` has 1 channel
-        with 4 spherical harmonic coefficients with 1024 samples or frequency
-        bins each. Time data is converted to ``float``. Frequency is
-        converted to ``complex`` and must be provided as single
-        sided spectra, i.e., for all frequencies between 0 Hz and
-        half the sampling rate.
+        samples/frequency domain bins and the second to last the spherical
+        harmonic coefficients. If the raw data have more then 3 dimensions
+        `sh_caxis` defines the axis holding the spherical harmonic
+        coefficients. The default is -1 (second to last channel axis).
+        Accordingly, the default data shape follows the 'C' memory layout,
+        e.g. data of ``shape = (1, 4, 1024)`` has 1 channel with 4 spherical
+        harmonic coefficients with 1024 samples or frequency bins each, and
+        `sh_caxis` = -1. The data can be ``int``, ``float`` or ``complex``.
+        Data of type ``int`` is converted to ``float``. Frequency is converted
+        to ``complex`` and must be provided as single sided spectra, i.e., for
+        all frequencies between 0 Hz and half the sampling rate.
     sampling_rate : double
         Sampling rate in Hz
     basis_type : str
@@ -560,9 +582,12 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         or real-valued. If ``True`` and `domain` is ``'time'``, the
         input data will be cast to complex. The default is ``False``.
     sh_caxis : int
-        Specifies which axis of data holds the spherical harmonic coefficients.
-        Negative indexing, i.e., interpreted relative to the end of the array.
-        The default is -1.
+        Specifies which channel axis of data holds the spherical harmonic
+        coefficients. Must be an integer smaller than or equal to -1.
+        The default -1 refers to the last channel axis; a value of -2
+        would refer to the second last channel axis. See
+        https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+        for more details.
 
     References
     ----------
@@ -591,7 +616,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
 
         if sh_caxis > 0:
             raise ValueError("sh_caxis has to be a negative integer.")
-        if abs(sh_caxis) >= data.ndim:
+        if abs(sh_caxis) > data.ndim:
             raise ValueError(f"sh_caxis ({sh_caxis}) exceeds the number of "
                              f"dimensions of data ({data.ndim})")
 
@@ -649,9 +674,12 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
             or real-valued. If ``True`` and `domain` is ``'time'``, the
             input data will be cast to complex. The default is ``False``.
         sh_caxis : int
-            Specifies which axis of data holds the spherical harmonic
-            coefficients. Negative indexing, i.e., interpreted relative to the
-            end of the array. The default is -1.
+            Specifies which channel axis of data holds the spherical harmonic
+            coefficients. Must be an integer smaller than or equal to -1.
+            The default -1 refers to the last channel axis; a value of -2
+            would refer to the second last channel axis. See
+            https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis>
+            for more details.
         """
         return cls(data, sampling_rate,
                    basis_type=sh_definition.basis_type,

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -193,11 +193,13 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
         Domain of data. The default is ``'time'``
     comment : str
         A comment related to `data`. The default is ``None``.
-    caxis_spherical_harmonics : int
-        Specifies which channel axis of data holds the spherical harmonic
-        coefficients. Must be an integer smaller than or equal to -1.
-        The default -1 refers to the last channel axis; a value of -2
-        would refer to the second last channel axis. See
+    caxis_spherical_harmonics : int, tuple
+        Specifies which channel axis (or axes) of data holds the spherical
+        harmonic coefficients. A tuple of integers can be used to specify
+        multiple spherical harmonics channel axes. Each value must be an
+        integer smaller than or equal to -1. The default -1 refers to the last
+        channel axis; a value of -2 would refer to the second last channel
+        axis. See
         https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
         for more details.
 
@@ -286,11 +288,13 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
     is_complex : bool, optional
         A flag which indicates if the time data are real or complex-valued.
         The default is ``False``.
-    caxis_spherical_harmonics : int
-        Specifies which channel axis of data holds the spherical harmonic
-        coefficients. Must be an integer smaller than or equal to -1.
-        The default -1 refers to the last channel axis; a value of -2
-        would refer to the second last channel axis. See
+    caxis_spherical_harmonics : int, tuple
+        Specifies which channel axis (or axes) of data holds the spherical
+        harmonic coefficients. A tuple of integers can be used to specify
+        multiple spherical harmonics channel axes. Each value must be an
+        integer smaller than or equal to -1. The default -1 refers to the last
+        channel axis; a value of -2 would refer to the second last channel
+        axis. See
         https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
         for more details.
     """
@@ -303,8 +307,17 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
             raise ValueError(
                 "Complex spherical harmonic basis requires "
                 "complex time data. Set is_complex=True.")
-        if abs(caxis_spherical_harmonics) > data.ndim:
-            raise ValueError(
+
+        if isinstance(caxis_spherical_harmonics, tuple):
+            for caxis in caxis_spherical_harmonics:
+                if abs(caxis) > data.ndim:
+                    raise ValueError(
+                        f"caxis_spherical_harmonics "
+                        f"({caxis_spherical_harmonics}) exceeds the number "
+                        f"of dimensions of data ({data.ndim})")
+        else:
+            if abs(caxis_spherical_harmonics) > data.ndim:
+                raise ValueError(
                     f"caxis_spherical_harmonics ({caxis_spherical_harmonics}) "
                     f"exceeds the number of dimensions of data ({data.ndim})")
 
@@ -354,10 +367,15 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
         is_complex : bool, optional
             A flag which indicates if the time data are real or complex-valued.
             The default is ``False``.
-        sh_caxis : int
-            Specifies which axis of data holds the spherical harmonic
-            coefficients. Negative indexing, i.e., interpreted relative to the
-            end of the array. The default is second last axis (-1).
+        caxis_spherical_harmonics : int, tuple
+            Specifies which channel axis (or axes) of data holds the spherical
+            harmonic coefficients. A tuple of integers can be used to specify
+            multiple spherical harmonics channel axes. Each value must be an
+            integer smaller than or equal to -1. The default -1 refers to the
+            last channel axis; a value of -2 would refer to the second last
+            channel axis. See
+            https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
+            for more details.
         """
         return cls(data, times,
                    basis_type=sh_definition.basis_type,
@@ -428,11 +446,13 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
         and ``False`` for real `basis_type`.
     comment : str
         A comment related to `data`. The default is ``""``.
-    caxis_spherical_harmonics : int
-        Specifies which channel axis of data holds the spherical harmonic
-        coefficients. Must be an integer smaller than or equal to -1.
-        The default -1 refers to the last channel axis; a value of -2
-        would refer to the second last channel axis. See
+    caxis_spherical_harmonics : int, tuple
+        Specifies which channel axis (or axes) of data holds the spherical
+        harmonic coefficients. A tuple of integers can be used to specify
+        multiple spherical harmonics channel axes. Each value must be an
+        integer smaller than or equal to -1. The default -1 refers to the last
+        channel axis; a value of -2 would refer to the second last channel
+        axis. See
         https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
         for more details.
     """
@@ -441,8 +461,16 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
                  channel_convention, condon_shortley, comment="",
                  caxis_spherical_harmonics=-1):
 
-        if abs(caxis_spherical_harmonics) > data.ndim:
-            raise ValueError(
+        if isinstance(caxis_spherical_harmonics, tuple):
+            for caxis in caxis_spherical_harmonics:
+                if abs(caxis) > data.ndim:
+                    raise ValueError(
+                        f"caxis_spherical_harmonics "
+                        f"({caxis_spherical_harmonics}) exceeds the number "
+                        f"of dimensions of data ({data.ndim})")
+        else:
+            if abs(caxis_spherical_harmonics) > data.ndim:
+                raise ValueError(
                     f"caxis_spherical_harmonics ({caxis_spherical_harmonics}) "
                     f"exceeds the number of dimensions of data ({data.ndim})")
 
@@ -489,11 +517,13 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
             the size of the last dimension of `data`, i.e., ``data.shape[-1]``.
         comment : str
             A comment related to `data`. The default is ``None``.
-        caxis_spherical_harmonics : int
-            Specifies which channel axis of data holds the spherical harmonic
-            coefficients. Must be an integer smaller than or equal to -1.
-            The default -1 refers to the last channel axis; a value of -2
-            would refer to the second last channel axis. See
+        caxis_spherical_harmonics : int, tuple
+            Specifies which channel axis (or axes) of data holds the spherical
+            harmonic coefficients. A tuple of integers can be used to specify
+            multiple spherical harmonics channel axes. Each value must be an
+            integer smaller than or equal to -1. The default -1 refers to the
+            last channel axis; a value of -2 would refer to the second last
+            channel axis. See
             https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
             for more details.
         """
@@ -592,11 +622,13 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
         Specifies if the underlying time domain data are complex
         or real-valued. If ``True`` and `domain` is ``'time'``, the
         input data will be cast to complex. The default is ``False``.
-    caxis_spherical_harmonics : int
-        Specifies which channel axis of data holds the spherical harmonic
-        coefficients. Must be an integer smaller than or equal to -1.
-        The default -1 refers to the last channel axis; a value of -2
-        would refer to the second last channel axis. See
+    caxis_spherical_harmonics : int, tuple
+        Specifies which channel axis (or axes) of data holds the spherical
+        harmonic coefficients. A tuple of integers can be used to specify
+        multiple spherical harmonics channel axes. Each value must be an
+        integer smaller than or equal to -1. The default -1 refers to the last
+        channel axis; a value of -2 would refer to the second last channel
+        axis. See
         https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
         for more details.
 
@@ -625,10 +657,18 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
                  is_complex=False,
                  caxis_spherical_harmonics=-1):
 
-        if abs(caxis_spherical_harmonics) > data.ndim:
-            raise ValueError(
-                f"caxis_spherical_harmonics ({caxis_spherical_harmonics}) "
-                f"exceeds the number of dimensions of data ({data.ndim})")
+        if isinstance(caxis_spherical_harmonics, tuple):
+            for caxis in caxis_spherical_harmonics:
+                if abs(caxis) > data.ndim:
+                    raise ValueError(
+                        f"caxis_spherical_harmonics "
+                        f"({caxis_spherical_harmonics}) exceeds the number "
+                        f"of dimensions of data ({data.ndim})")
+        else:
+            if abs(caxis_spherical_harmonics) > data.ndim:
+                raise ValueError(
+                    f"caxis_spherical_harmonics ({caxis_spherical_harmonics}) "
+                    f"exceeds the number of dimensions of data ({data.ndim})")
 
         data = _atleast_3d_first_dimension(data)
         _assert_valid_number_of_sh_channels(data.shape,
@@ -689,11 +729,13 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
             Specifies if the underlying time domain data are complex
             or real-valued. If ``True`` and `domain` is ``'time'``, the
             input data will be cast to complex. The default is ``False``.
-        caxis_spherical_harmonics : int
-            Specifies which channel axis of data holds the spherical harmonic
-            coefficients. Must be an integer smaller than or equal to -1.
-            The default -1 refers to the last channel axis; a value of -2
-            would refer to the second last channel axis. See
+        caxis_spherical_harmonics : int, tuple
+            Specifies which channel axis (or axes) of data holds the spherical
+            harmonic coefficients. A tuple of integers can be used to specify
+            multiple spherical harmonics channel axes. Each value must be an
+            integer smaller than or equal to -1. The default -1 refers to the
+            last channel axis; a value of -2 would refer to the second last
+            channel axis. See
             https://pyfar-gallery.readthedocs.io/en/latest/gallery/interactive/pyfar_audio_objects.html#Signal-cshape,-length,-and-caxis
             for more details.
         """

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -72,13 +72,16 @@ def _assert_valid_number_of_sh_channels(shape, sh_axis):
         Raised if the number of spherical harmonic channels does not match
         (n_max + 1)^2 for an integer n_max.
     """
+    # convert to tuple
+    sh_axes = (sh_axis,) if isinstance(sh_axis, int) else tuple(sh_axis)
 
-    sh_channels = shape[sh_axis]
-    n_max = np.sqrt(sh_channels)-1
-    if n_max - int(n_max) != 0:
-        raise ValueError(
-            "Invalid number of spherical harmonic channels: "
-            f"{sh_channels}. It must match (n_max + 1)^2.")
+    for sh_axis in sh_axes:
+        sh_channels = shape[sh_axis]
+        n_max = np.sqrt(sh_channels)-1
+        if n_max - int(n_max) != 0:
+            raise ValueError(
+                "Invalid number of spherical harmonic channels: "
+                f"{sh_channels}. It must match (n_max + 1)^2.")
 
 
 def _convert_to_standard_definition(
@@ -308,22 +311,20 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
                 "Complex spherical harmonic basis requires "
                 "complex time data. Set is_complex=True.")
 
-        if isinstance(caxis_spherical_harmonics, tuple):
-            for caxis in caxis_spherical_harmonics:
-                if abs(caxis) > data.ndim:
-                    raise ValueError(
-                        f"caxis_spherical_harmonics "
-                        f"({caxis_spherical_harmonics}) exceeds the number "
-                        f"of dimensions of data ({data.ndim})")
-        else:
-            if abs(caxis_spherical_harmonics) > data.ndim:
+        if isinstance(caxis_spherical_harmonics, int):
+            caxis_spherical_harmonics = (caxis_spherical_harmonics, )
+
+        for caxis in caxis_spherical_harmonics:
+            if abs(caxis) > data.ndim:
                 raise ValueError(
-                    f"caxis_spherical_harmonics ({caxis_spherical_harmonics}) "
-                    f"exceeds the number of dimensions of data ({data.ndim})")
+                    f"caxis_spherical_harmonics "
+                    f"({caxis_spherical_harmonics}) exceeds the number "
+                    f"of dimensions of data ({data.ndim})")
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape,
-                                            caxis_spherical_harmonics-1)
+
+        axes_sh = tuple(x - 1 for x in caxis_spherical_harmonics)
+        _assert_valid_number_of_sh_channels(data.shape, axes_sh)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
@@ -396,8 +397,9 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
     def time(self, value):
         """Return or set the time data."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape,
-                                            self._caxis_spherical_harmonics-1)
+
+        axes_sh = tuple(x - 1 for x in self._caxis_spherical_harmonics)
+        _assert_valid_number_of_sh_channels(value.shape, axes_sh)
 
         value = _convert_to_standard_definition(
             value, self.normalization, self.channel_convention)
@@ -461,22 +463,20 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
                  channel_convention, condon_shortley, comment="",
                  caxis_spherical_harmonics=-1):
 
-        if isinstance(caxis_spherical_harmonics, tuple):
-            for caxis in caxis_spherical_harmonics:
-                if abs(caxis) > data.ndim:
-                    raise ValueError(
-                        f"caxis_spherical_harmonics "
-                        f"({caxis_spherical_harmonics}) exceeds the number "
-                        f"of dimensions of data ({data.ndim})")
-        else:
-            if abs(caxis_spherical_harmonics) > data.ndim:
+        if isinstance(caxis_spherical_harmonics, int):
+            caxis_spherical_harmonics = (caxis_spherical_harmonics, )
+
+        for caxis in caxis_spherical_harmonics:
+            if abs(caxis) > data.ndim:
                 raise ValueError(
-                    f"caxis_spherical_harmonics ({caxis_spherical_harmonics}) "
-                    f"exceeds the number of dimensions of data ({data.ndim})")
+                    f"caxis_spherical_harmonics "
+                    f"({caxis_spherical_harmonics}) exceeds the number "
+                    f"of dimensions of data ({data.ndim})")
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape,
-                                            caxis_spherical_harmonics-1)
+
+        axes_sh = tuple(x - 1 for x in caxis_spherical_harmonics)
+        _assert_valid_number_of_sh_channels(data.shape, axes_sh)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
@@ -548,11 +548,12 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
     def freq(self, value):
         """Return or set the data in the frequency domain."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape,
-                                            self._caxis_spherical_harmonics-1)
 
+        axes_sh = tuple(x - 1 for x in self._caxis_spherical_harmonics)
+
+        _assert_valid_number_of_sh_channels(value.shape, axes_sh)
         value = _convert_to_standard_definition(
-            value, self.normalization, self.channel_convention)
+            value, self.normalization, self.channel_convention, axes_sh)
 
         FrequencyData.freq.fset(self, value)
 
@@ -657,22 +658,20 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
                  is_complex=False,
                  caxis_spherical_harmonics=-1):
 
-        if isinstance(caxis_spherical_harmonics, tuple):
-            for caxis in caxis_spherical_harmonics:
-                if abs(caxis) > data.ndim:
-                    raise ValueError(
-                        f"caxis_spherical_harmonics "
-                        f"({caxis_spherical_harmonics}) exceeds the number "
-                        f"of dimensions of data ({data.ndim})")
-        else:
-            if abs(caxis_spherical_harmonics) > data.ndim:
+        if isinstance(caxis_spherical_harmonics, int):
+            caxis_spherical_harmonics = (caxis_spherical_harmonics, )
+
+        for caxis in caxis_spherical_harmonics:
+            if abs(caxis) > data.ndim:
                 raise ValueError(
-                    f"caxis_spherical_harmonics ({caxis_spherical_harmonics}) "
-                    f"exceeds the number of dimensions of data ({data.ndim})")
+                    f"caxis_spherical_harmonics "
+                    f"({caxis_spherical_harmonics}) exceeds the number "
+                    f"of dimensions of data ({data.ndim})")
 
         data = _atleast_3d_first_dimension(data)
-        _assert_valid_number_of_sh_channels(data.shape,
-                                            caxis_spherical_harmonics-1)
+
+        axes_sh = tuple(x - 1 for x in caxis_spherical_harmonics)
+        _assert_valid_number_of_sh_channels(data.shape, axes_sh)
 
         _SphericalHarmonicAudio.__init__(
             self, basis_type, normalization, channel_convention,
@@ -761,11 +760,12 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     def freq(self, value):
         """Return or set the data in the frequency domain."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape,
-                                            self._caxis_spherical_harmonics-1)
 
+        axes_sh = tuple(x - 1 for x in self._caxis_spherical_harmonics)
+
+        _assert_valid_number_of_sh_channels(value.shape, axes_sh)
         value = _convert_to_standard_definition(
-            value, self.normalization, self.channel_convention)
+            value, self.normalization, self.channel_convention, axes_sh)
 
         Signal.freq.fset(self, value)
 
@@ -782,12 +782,12 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     def freq_raw(self, value):
         """Return or set the frequency domain data without normalization."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape,
-                                            self._caxis_spherical_harmonics-1)
 
+        axes_sh = tuple(x - 1 for x in self._caxis_spherical_harmonics)
+
+        _assert_valid_number_of_sh_channels(value.shape, axes_sh)
         value = _convert_to_standard_definition(
-            value, self.normalization, self.channel_convention,
-            self._caxis_spherical_harmonics-1)
+            value, self.normalization, self.channel_convention, axes_sh)
 
         Signal.freq_raw.fset(self, value)
 
@@ -804,10 +804,11 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     def time(self, value):
         """Return or set the time data."""
         value = _atleast_3d_first_dimension(value)
-        _assert_valid_number_of_sh_channels(value.shape,
-                                            self._caxis_spherical_harmonics-1)
 
+        axes_sh = tuple(x - 1 for x in self._caxis_spherical_harmonics)
+
+        _assert_valid_number_of_sh_channels(value.shape, axes_sh)
         value = _convert_to_standard_definition(
-            value, self.normalization, self.channel_convention,
-            self._caxis_spherical_harmonics-1)
+            value, self.normalization, self.channel_convention, axes_sh)
+
         Signal.time.fset(self, value)

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -538,11 +538,12 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
     @property
     def freq(self):
         """Return or set the data in the frequency domain."""
+        axes_sh = tuple(x - 1 for x in self._caxis_spherical_harmonics)
         return _convert_from_standard_definition(
                     FrequencyData.freq.fget(self),
                     self.normalization,
                     self.channel_convention,
-                    self._caxis_spherical_harmonics-1)
+                    axes_sh)
 
     @freq.setter
     def freq(self, value):
@@ -750,11 +751,12 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     @property
     def freq(self):
         """Return or set the data in the frequency domain."""
+        axes_sh = tuple(x - 1 for x in self._caxis_spherical_harmonics)
         return _convert_from_standard_definition(
                     Signal.freq.fget(self),
                     self.normalization,
                     self.channel_convention,
-                    self._caxis_spherical_harmonics-1)
+                    axes_sh)
 
     @freq.setter
     def freq(self, value):
@@ -772,11 +774,12 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     @property
     def freq_raw(self):
         """Return or set the frequency domain data without normalization."""
+        axes_sh = tuple(x - 1 for x in self._caxis_spherical_harmonics)
         return _convert_from_standard_definition(
                     Signal.freq_raw.fget(self),
                     self.normalization,
                     self.channel_convention,
-                    self._caxis_spherical_harmonics-1)
+                    axes_sh)
 
     @freq_raw.setter
     def freq_raw(self, value):
@@ -794,11 +797,12 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
     @property
     def time(self):
         """Return or set the time data."""
+        axes_sh = tuple(x - 1 for x in self._caxis_spherical_harmonics)
         return _convert_from_standard_definition(
                     Signal.time.fget(self),
                     self.normalization,
                     self.channel_convention,
-                    self._caxis_spherical_harmonics-1)
+                    axes_sh)
 
     @time.setter
     def time(self, value):

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -75,13 +75,19 @@ def _assert_valid_number_of_sh_channels(shape, sh_axis):
     # convert to tuple
     sh_axes = (sh_axis,) if isinstance(sh_axis, int) else tuple(sh_axis)
 
-    for sh_axis in sh_axes:
-        sh_channels = shape[sh_axis]
-        n_max = np.sqrt(sh_channels)-1
-        if n_max - int(n_max) != 0:
-            raise ValueError(
-                "Invalid number of spherical harmonic channels: "
-                f"{sh_channels}. It must match (n_max + 1)^2.")
+    # check if all spherical harmonic channels have same length
+    sh_channels = [shape[a] for a in sh_axes]
+    if len(set(sh_channels)) != 1:
+        raise ValueError("All SH axes must have the same number of channels, "
+                         f"but got {sh_channels}.")
+
+    # check if all spherical harmonic channels match n_max
+    sh_channels = sh_channels[0]
+    n_max = np.sqrt(sh_channels)-1
+    if n_max - int(n_max) != 0:
+        raise ValueError(
+            "Invalid number of spherical harmonic channels: "
+            f"{sh_channels}. It must match (n_max + 1)^2.")
 
 
 def _convert_to_standard_definition(

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -234,6 +234,10 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
     @property
     def caxis_spherical_harmonics(self):
         """Get the spherical harmonic axis"""
+
+        if len(self._caxis_spherical_harmonics) == 1:
+            return self._caxis_spherical_harmonics[0]
+
         return self._caxis_spherical_harmonics
 
     @_SphericalHarmonicBase.basis_type.setter
@@ -324,7 +328,7 @@ class SphericalHarmonicTimeData(_SphericalHarmonicAudio, TimeData):
             if abs(caxis) > data.ndim:
                 raise ValueError(
                     f"caxis_spherical_harmonics "
-                    f"({caxis_spherical_harmonics}) exceeds the number "
+                    f"({caxis}) exceeds the number "
                     f"of dimensions of data ({data.ndim})")
 
         data = _atleast_3d_first_dimension(data)
@@ -476,7 +480,7 @@ class SphericalHarmonicFrequencyData(_SphericalHarmonicAudio, FrequencyData):
             if abs(caxis) > data.ndim:
                 raise ValueError(
                     f"caxis_spherical_harmonics "
-                    f"({caxis_spherical_harmonics}) exceeds the number "
+                    f"({caxis}) exceeds the number "
                     f"of dimensions of data ({data.ndim})")
 
         data = _atleast_3d_first_dimension(data)
@@ -672,7 +676,7 @@ class SphericalHarmonicSignal(_SphericalHarmonicAudio, Signal):
             if abs(caxis) > data.ndim:
                 raise ValueError(
                     f"caxis_spherical_harmonics "
-                    f"({caxis_spherical_harmonics}) exceeds the number "
+                    f"({caxis}) exceeds the number "
                     f"of dimensions of data ({data.ndim})")
 
         data = _atleast_3d_first_dimension(data)

--- a/spharpy/classes/audio.py
+++ b/spharpy/classes/audio.py
@@ -233,7 +233,7 @@ class _SphericalHarmonicAudio(_Audio, _SphericalHarmonicBase, ABC):
 
     @property
     def caxis_spherical_harmonics(self):
-        """Get the spherical harmonic axis"""
+        """Get the spherical harmonic axis."""
 
         if len(self._caxis_spherical_harmonics) == 1:
             return self._caxis_spherical_harmonics[0]

--- a/spharpy/spherical.py
+++ b/spharpy/spherical.py
@@ -282,7 +282,20 @@ def renormalize(data, channel_convention, current_norm, target_norm, axis):
     data : ndarray
         Renormalized data
     """
-    sh_channels = data.shape[axis]
+    if isinstance(axis, int):
+        axis = (axis,)
+
+    # check if all sh_channels match
+    sh_channels = [data.shape[a] for a in axis]
+
+    if len(set(sh_channels)) != 1:
+        raise ValueError(
+            "All SH axes must have the same number of channels, "
+            f"but got {sh_channels}"
+        )
+
+    sh_channels = sh_channels[0]
+
     if np.sqrt(sh_channels) % 1:
         raise ValueError("Invalid number of SH channels: "
                          f"{data.shape[-2]}. It must match (n_max + 1)^2.")
@@ -314,10 +327,11 @@ def renormalize(data, channel_convention, current_norm, target_norm, axis):
     # sure that the factors can be applied, new axes must be added. This is
     # done by reshaping to the following shape
     shape = [1] * data.ndim
-    shape[axis] = data.shape[axis]
+    for a in axis:
+        shape[a] = sh_channels
 
     data_renorm = data.copy()
-    # normalize to 'n3d'
+    # normalize to 'N3D'
     if current_norm == 'NM':
         data_renorm /= np.sqrt(4*np.pi)
     if current_norm == 'SN3D':
@@ -364,6 +378,9 @@ def change_channel_convention(data, current, target, axis):
     data : ndarray
         Data with changed channel convention
     """
+    if isinstance(axis, int):
+        axis = (axis,)
+
     if current not in ["ACN", "FuMa"]:
         raise ValueError("Invalid current channel convention. Has to be "
                          f"'ACN' or 'FuMa', but is {current}")
@@ -375,7 +392,18 @@ def change_channel_convention(data, current, target, axis):
     if current == target:
         return data
 
-    acn = np.arange(data.shape[axis])
+    # check if all sh_channels match
+    sh_channels = [data.shape[a] for a in axis]
+
+    if len(set(sh_channels)) != 1:
+        raise ValueError(
+            "All SH axes must have the same number of channels, "
+            f"but got {sh_channels}"
+        )
+
+    sh_channels = sh_channels[0]
+    acn = np.arange(sh_channels)
+
     if current == 'ACN':
         n, m = acn_to_nm(acn)
         idx = nm_to_fuma(n, m)
@@ -383,7 +411,13 @@ def change_channel_convention(data, current, target, axis):
         n, m = fuma_to_nm(acn)
         idx = nm_to_acn(n, m)
 
-    return np.take(data, idx, axis=axis)
+    # return np.take(data, idx, axis=axis)
+    data_out = data.copy()
+
+    for a in axis:
+        data_out = np.take(data_out, idx, axis=a)
+
+    return data_out
 
 
 def spherical_harmonic_basis(

--- a/spharpy/spherical.py
+++ b/spharpy/spherical.py
@@ -318,8 +318,9 @@ def renormalize(data, channel_convention, current_norm, target_norm, axis):
     # sure that the factors can be applied, new axes must be added. This is
     # done by reshaping to the following shape
     shape = [1] * data.ndim
-    for a in axis:
-        shape[a] = sh_channels
+    # for a in axis:
+    #     shape[a] = sh_channels
+    shape[axis[0]] = sh_channels
 
     data_renorm = data.copy()
     # normalize to 'N3D'

--- a/spharpy/spherical.py
+++ b/spharpy/spherical.py
@@ -285,20 +285,11 @@ def renormalize(data, channel_convention, current_norm, target_norm, axis):
     if isinstance(axis, int):
         axis = (axis,)
 
-    # check if all sh_channels match
-    sh_channels = [data.shape[a] for a in axis]
-
-    if len(set(sh_channels)) != 1:
-        raise ValueError(
-            "All SH axes must have the same number of channels, "
-            f"but got {sh_channels}"
-        )
-
-    sh_channels = sh_channels[0]
+    sh_channels = data.shape[axis[0]]
 
     if np.sqrt(sh_channels) % 1:
         raise ValueError("Invalid number of SH channels: "
-                         f"{data.shape[-2]}. It must match (n_max + 1)^2.")
+                         f"{sh_channels}. It must match (n_max + 1)^2.")
 
     if channel_convention not in ["ACN", "FuMa"]:
         raise ValueError("Invalid channel convention. Has to be 'ACN' "
@@ -316,7 +307,7 @@ def renormalize(data, channel_convention, current_norm, target_norm, axis):
     if current_norm == target_norm:
         return data
 
-    acn = np.arange(data.shape[axis])
+    acn = np.arange(data.shape[axis[0]])
 
     if channel_convention == "FuMa":
         orders, _ = fuma_to_nm(acn)
@@ -392,16 +383,7 @@ def change_channel_convention(data, current, target, axis):
     if current == target:
         return data
 
-    # check if all sh_channels match
-    sh_channels = [data.shape[a] for a in axis]
-
-    if len(set(sh_channels)) != 1:
-        raise ValueError(
-            "All SH axes must have the same number of channels, "
-            f"but got {sh_channels}"
-        )
-
-    sh_channels = sh_channels[0]
+    sh_channels = data.shape[axis[0]]
     acn = np.arange(sh_channels)
 
     if current == 'ACN':

--- a/spharpy/spherical.py
+++ b/spharpy/spherical.py
@@ -318,8 +318,7 @@ def renormalize(data, channel_convention, current_norm, target_norm, axis):
     # sure that the factors can be applied, new axes must be added. This is
     # done by reshaping to the following shape
     shape = [1] * data.ndim
-    # for a in axis:
-    #     shape[a] = sh_channels
+
     shape[axis[0]] = sh_channels
 
     data_renorm = data.copy()
@@ -394,7 +393,6 @@ def change_channel_convention(data, current, target, axis):
         n, m = fuma_to_nm(acn)
         idx = nm_to_acn(n, m)
 
-    # return np.take(data, idx, axis=axis)
     data_out = data.copy()
 
     for a in axis:

--- a/spharpy/transforms/rotations.py
+++ b/spharpy/transforms/rotations.py
@@ -288,7 +288,21 @@ class SphericalHarmonicRotation(Rotation):
         D = self.as_spherical_harmonic_matrix(target_definition)
         M = np.linalg.multi_dot(list(D)) if D.ndim > 2 else D
 
-        rotated_data = np.einsum('ij, ljt -> lit', M, target._data)
+        data = target._data
+        sh_caxis = target.sh_caxis
+
+        # find non negative axis
+        sh_caxis = np.core.numeric.normalize_axis_index(sh_caxis, data.ndim)
+
+        # move SH axis to front
+        data = np.moveaxis(data, sh_caxis, 0)
+
+        # apply rotation
+        rotated_data = np.tensordot(M, data, axes=(1, 0))
+
+        # move SH axis back to original position
+        rotated_data = np.moveaxis(rotated_data, 0, sh_caxis)
+
         rotated = target.copy()
         rotated._data = rotated_data
         return rotated

--- a/spharpy/transforms/rotations.py
+++ b/spharpy/transforms/rotations.py
@@ -289,14 +289,11 @@ class SphericalHarmonicRotation(Rotation):
         M = np.linalg.multi_dot(list(D)) if D.ndim > 2 else D
 
         data = target._data
-        sh_caxis = target.sh_caxis
-
-        # find non negative axis
-        sh_caxis = np.core.numeric.normalize_axis_index(sh_caxis, data.ndim)
+        sh_caxis = target.caxis_spherical_harmonics - 1
 
         # move SH axis to front
         data = np.moveaxis(data, sh_caxis, 0)
-
+        
         # apply rotation
         rotated_data = np.tensordot(M, data, axes=(1, 0))
 

--- a/spharpy/transforms/rotations.py
+++ b/spharpy/transforms/rotations.py
@@ -293,7 +293,7 @@ class SphericalHarmonicRotation(Rotation):
 
         # move SH axis to front
         data = np.moveaxis(data, sh_caxis, 0)
-        
+
         # apply rotation
         rotated_data = np.tensordot(M, data, axes=(1, 0))
 

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -136,6 +136,107 @@ def test_renormalize(channel_convention):
                             np.ones((4, 2)))
 
 
+@pytest.mark.parametrize("channel_convention", ['ACN', 'FuMa'])
+def test_renormalize_multichannel(channel_convention):
+    sh_data = np.ones((4, 4, 2))
+
+    # test from n3d to maxN
+    current_norm = 'N3D'
+    target_norm = 'maxN'
+    sh_data_n3d_to_maxN = sh.renormalize(sh_data, channel_convention,
+                                         current_norm,
+                                         target_norm, axis=(0, 1))
+    sh_data_ref = np.array([[np.sqrt(1 / 2), np.sqrt(1 / 2)],
+                            [np.sqrt(1 / 3), np.sqrt(1 / 3)],
+                            [np.sqrt(1 / 3), np.sqrt(1 / 3)],
+                            [np.sqrt(1 / 3), np.sqrt(1 / 3)]])
+
+    sh_data_ref = np.broadcast_to(sh_data_ref[:, np.newaxis, :],
+                                  (4, 4, 2))
+
+    np.testing.assert_equal(sh_data_n3d_to_maxN, sh_data_ref)
+
+    # test from n3d to nm
+    target_norm = 'NM'
+    sh_data_n3d_to_nm = sh.renormalize(sh_data, channel_convention,
+                                       current_norm,
+                                       target_norm, axis=(0, 1))
+    np.testing.assert_equal(sh_data_n3d_to_nm,
+                            sh_data * np.sqrt(4 * np.pi))
+
+    # test from maxN to n3d
+    current_norm = 'maxN'
+    target_norm = 'N3D'
+    sh_data_maxN_to_n3d = sh.renormalize(sh_data_n3d_to_maxN,
+                                         channel_convention,
+                                         current_norm,
+                                         target_norm, axis=(0, 1))
+    np.testing.assert_equal(sh_data_maxN_to_n3d, np.ones((4, 4, 2)))
+
+    # test from maxN to sn3d
+    current_norm = 'maxN'
+    target_norm = 'SN3D'
+    sh_data_maxN_to_sn3d = sh.renormalize(sh_data_n3d_to_maxN,
+                                          channel_convention,
+                                          current_norm,
+                                          target_norm, axis=(0, 1))
+    # back to n3d to check against ones
+    sh_data_sn3d_to_n3d = sh.renormalize(sh_data_maxN_to_sn3d,
+                                         channel_convention,
+                                         'SN3D',
+                                         'N3D', axis=(0, 1))
+    np.testing.assert_equal(sh_data_sn3d_to_n3d, np.ones((4, 4, 2)))
+
+    # test from n3d to sn3d
+    current_norm = 'N3D'
+    target_norm = 'SN3D'
+    sh_data_n3d_to_sn3d = sh.renormalize(sh_data, channel_convention,
+                                         current_norm,
+                                         target_norm, axis=(0, 1))
+    sh_data_ref = np.array([[1 / np.sqrt(2 * 0 + 1), 1 / np.sqrt(2 * 0 + 1)],
+                            [1 / np.sqrt(2 * 1 + 1), 1 / np.sqrt(2 * 1 + 1)],
+                            [1 / np.sqrt(2 * 1 + 1), 1 / np.sqrt(2 * 1 + 1)],
+                            [1 / np.sqrt(2 * 1 + 1), 1 / np.sqrt(2 * 1 + 1)]])
+    sh_data_ref = np.broadcast_to(sh_data_ref[:, np.newaxis, :],
+                                  (4, 4, 2))
+
+    np.testing.assert_equal(sh_data_n3d_to_sn3d, sh_data_ref)
+
+    # test from sn3d to n3d
+    current_norm = 'SN3D'
+    target_norm = 'N3D'
+    sh_data_sn3d_to_n3d = sh.renormalize(sh_data_n3d_to_sn3d,
+                                         channel_convention,
+                                         current_norm,
+                                         target_norm, axis=(0, 1))
+    np.testing.assert_equal(sh_data_sn3d_to_n3d, np.ones((4, 4, 2)))
+
+    # test from sn3d to maxN
+    current_norm = 'SN3D'
+    target_norm = 'maxN'
+    sh_data_sn3d_to_maxN = sh.renormalize(sh_data_n3d_to_sn3d,
+                                          channel_convention,
+                                          current_norm,
+                                          target_norm, axis=(0, 1))
+
+    # test from sn3d to snm
+    current_norm = 'SN3D'
+    target_norm = 'SNM'
+    sh_data_sn3d_to_snm = sh.renormalize(sh_data_n3d_to_sn3d,
+                                         channel_convention,
+                                         current_norm,
+                                         target_norm, axis=(0, 1))
+    np.testing.assert_equal(sh_data_sn3d_to_snm,
+                            sh_data_n3d_to_sn3d * np.sqrt(4 * np.pi))
+
+    # back to n3d to check against ones
+    sh_data_maxN_to_n3d = sh.renormalize(sh_data_sn3d_to_maxN,
+                                         channel_convention,
+                                         'maxN',
+                                         'N3D', axis=(0, 1))
+    np.testing.assert_equal(sh_data_maxN_to_n3d, np.ones((4, 4, 2)))
+
+
 def test_renormalize_wrong_channel_number():
     sh_data = np.ones((5, 2))
     with pytest.raises(
@@ -177,5 +278,31 @@ def test_change_channel_convention():
     current_channel_convention = 'FuMa'
     sh_data_new_convention = sh.change_channel_convention(
         sh_data_new_convention_fuma, current_channel_convention, 'ACN', axis=0)
+    np.testing.assert_equal(sh_data,
+                            sh_data_new_convention)
+
+
+def test_change_channel_convention_multichannel():
+    sh_data = np.array([[1., 1., 1.],
+                        [2., 2., 2.],
+                        [3., 3., 3.],
+                        [4., 4., 4.]])
+    # create multichannel sh data
+    sh_data = np.broadcast_to(sh_data[:, np.newaxis, :], (4, 4, 3)).copy()
+
+    # test conversion to FuMa
+    current_channel_convention = 'ACN'
+    sh_data_new_convention = sh.change_channel_convention(
+        sh_data, current_channel_convention, 'FuMa', axis=(0, 1))
+    fuma_idx = [0, 3, 1, 2]
+    sh_data_new_convention_fuma = sh_data[fuma_idx, :, :][:, fuma_idx, :]
+    np.testing.assert_equal(sh_data_new_convention_fuma,
+                            sh_data_new_convention)
+
+    # test conversion to acn
+    current_channel_convention = 'FuMa'
+    sh_data_new_convention = sh.change_channel_convention(
+        sh_data_new_convention_fuma, current_channel_convention, 'ACN',
+        axis=(0, 1))
     np.testing.assert_equal(sh_data,
                             sh_data_new_convention)

--- a/tests/test_spherical_harmonics_audio.py
+++ b/tests/test_spherical_harmonics_audio.py
@@ -39,7 +39,7 @@ def test_init_sh_time_data():
     sh_time_data = SphericalHarmonicTimeData(
         data, times,  basis_type='real', normalization='SN3D',
         channel_convention="ACN", condon_shortley=False,
-        comment="")
+        comment="", sh_caxis=-2)
     assert isinstance(sh_time_data, SphericalHarmonicTimeData)
     np.testing.assert_allclose(sh_time_data.time, data)
 
@@ -57,7 +57,7 @@ def test_sh_time_data_from_sh_definition():
     times = [1, 2, 3, 4]
 
     time_data_def = SphericalHarmonicTimeData.from_definition(
-        sh_definition=shd, data=data, times=times)
+        sh_definition=shd, data=data, times=times, sh_caxis=-2)
 
     assert isinstance(time_data_def, SphericalHarmonicTimeData)
 
@@ -66,7 +66,8 @@ def test_sh_time_data_from_sh_definition():
             times, basis_type='real',
             channel_convention='ACN',
             normalization='N3D',
-            condon_shortley=False)
+            condon_shortley=False,
+            sh_caxis=-2)
 
     assert time_data == time_data_def
 
@@ -77,7 +78,7 @@ def test_init_sh_frequency_data():
     sh_freq_data = SphericalHarmonicFrequencyData(
         data, frequencies, basis_type='real', normalization='SN3D',
         channel_convention="ACN", condon_shortley=False,
-        comment="")
+        comment="", sh_caxis=-2)
     assert isinstance(sh_freq_data, SphericalHarmonicFrequencyData)
     np.testing.assert_allclose(sh_freq_data.freq, data)
 
@@ -104,6 +105,7 @@ def test_sh_freq_data_from_sh_definition():
             freqs, basis_type='real',
             channel_convention='ACN',
             normalization='N3D',
-            condon_shortley=False)
+            condon_shortley=False,
+            sh_caxis=-2)
 
     assert freq_data == freq_data_def

--- a/tests/test_spherical_harmonics_audio.py
+++ b/tests/test_spherical_harmonics_audio.py
@@ -40,7 +40,7 @@ def test_init_sh_time_data():
     sh_time_data = SphericalHarmonicTimeData(
         data, times,  basis_type='real', normalization='SN3D',
         channel_convention="ACN", condon_shortley=False,
-        comment="", sh_caxis=-2)
+        comment="", sh_caxis=-1)
     assert isinstance(sh_time_data, SphericalHarmonicTimeData)
     np.testing.assert_allclose(sh_time_data.time, data)
 
@@ -58,7 +58,7 @@ def test_sh_time_data_from_sh_definition():
     times = [1, 2, 3, 4]
 
     time_data_def = SphericalHarmonicTimeData.from_definition(
-        sh_definition=shd, data=data, times=times, sh_caxis=-2)
+        sh_definition=shd, data=data, times=times, sh_caxis=-1)
 
     assert isinstance(time_data_def, SphericalHarmonicTimeData)
 
@@ -68,7 +68,7 @@ def test_sh_time_data_from_sh_definition():
             channel_convention='ACN',
             normalization='N3D',
             condon_shortley=False,
-            sh_caxis=-2)
+            sh_caxis=-1)
 
     assert time_data == time_data_def
 
@@ -79,7 +79,7 @@ def test_init_sh_frequency_data():
     sh_freq_data = SphericalHarmonicFrequencyData(
         data, frequencies, basis_type='real', normalization='SN3D',
         channel_convention="ACN", condon_shortley=False,
-        comment="", sh_caxis=-2)
+        comment="", sh_caxis=-1)
     assert isinstance(sh_freq_data, SphericalHarmonicFrequencyData)
     np.testing.assert_allclose(sh_freq_data.freq, data)
 
@@ -107,7 +107,7 @@ def test_sh_freq_data_from_sh_definition():
             channel_convention='ACN',
             normalization='N3D',
             condon_shortley=False,
-            sh_caxis=-2)
+            sh_caxis=-1)
 
     assert freq_data == freq_data_def
 

--- a/tests/test_spherical_harmonics_audio.py
+++ b/tests/test_spherical_harmonics_audio.py
@@ -5,6 +5,7 @@ from spharpy.classes.audio import (
 from spharpy import SphericalHarmonicDefinition
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 
 def test_atleast_3d_data():
@@ -109,3 +110,27 @@ def test_sh_freq_data_from_sh_definition():
             sh_caxis=-2)
 
     assert freq_data == freq_data_def
+
+
+def test_init_sh_time_data_wrong_sh_caxis():
+    data = np.ones((1, 4, 4))
+    times = [1, 2, 3, 4]
+
+    with pytest.raises(ValueError,
+                       match="sh_caxis has to be a negative integer."):
+        SphericalHarmonicTimeData(
+            data, times,  basis_type='real', normalization='SN3D',
+            channel_convention="ACN", condon_shortley=False,
+            comment="", sh_caxis=1)
+
+
+def test_init_sh_frequency_data_wrong_sh_caxis():
+    data = np.ones((1, 4, 4), dtype=complex)
+    frequencies = [1, 2, 3, 4]
+
+    with pytest.raises(ValueError,
+                       match="sh_caxis has to be a negative integer."):
+        SphericalHarmonicFrequencyData(
+            data, frequencies, basis_type='real', normalization='SN3D',
+            channel_convention="ACN", condon_shortley=False,
+            comment="", sh_caxis=1)

--- a/tests/test_spherical_harmonics_audio.py
+++ b/tests/test_spherical_harmonics_audio.py
@@ -41,7 +41,7 @@ def test_init_sh_time_data():
     sh_time_data = SphericalHarmonicTimeData(
         data, times,  basis_type='real', normalization='SN3D',
         channel_convention="ACN", condon_shortley=False,
-        comment="", sh_caxis=-1)
+        comment="", caxis_spherical_harmonics=-1)
     assert isinstance(sh_time_data, SphericalHarmonicTimeData)
     np.testing.assert_allclose(sh_time_data.time, data)
 
@@ -59,7 +59,8 @@ def test_sh_time_data_from_sh_definition():
     times = [1, 2, 3, 4]
 
     time_data_def = SphericalHarmonicTimeData.from_definition(
-        sh_definition=shd, data=data, times=times, sh_caxis=-1)
+        sh_definition=shd, data=data, times=times,
+        caxis_spherical_harmonics=-1)
 
     assert isinstance(time_data_def, SphericalHarmonicTimeData)
 
@@ -69,7 +70,7 @@ def test_sh_time_data_from_sh_definition():
             channel_convention='ACN',
             normalization='N3D',
             condon_shortley=False,
-            sh_caxis=-1)
+            caxis_spherical_harmonics=-1)
 
     assert time_data == time_data_def
 
@@ -80,7 +81,7 @@ def test_init_sh_frequency_data():
     sh_freq_data = SphericalHarmonicFrequencyData(
         data, frequencies, basis_type='real', normalization='SN3D',
         channel_convention="ACN", condon_shortley=False,
-        comment="", sh_caxis=-1)
+        comment="", caxis_spherical_harmonics=-1)
     assert isinstance(sh_freq_data, SphericalHarmonicFrequencyData)
     np.testing.assert_allclose(sh_freq_data.freq, data)
 
@@ -108,7 +109,7 @@ def test_sh_freq_data_from_sh_definition():
             channel_convention='ACN',
             normalization='N3D',
             condon_shortley=False,
-            sh_caxis=-1)
+            caxis_spherical_harmonics=-1)
 
     assert freq_data == freq_data_def
 
@@ -118,18 +119,13 @@ def test_init_sh_time_data_wrong_sh_caxis():
     times = [1, 2, 3, 4]
 
     with pytest.raises(ValueError,
-                       match="sh_caxis has to be a negative integer."):
+                       match=re.escape("caxis_spherical_harmonics (-4) "
+                                       "exceeds the number of dimensions of "
+                                       "data (3)")):
         SphericalHarmonicTimeData(
             data, times,  basis_type='real', normalization='SN3D',
             channel_convention="ACN", condon_shortley=False,
-            comment="", sh_caxis=1)
-    with pytest.raises(ValueError,
-                       match=re.escape("sh_caxis (-4) exceeds the number of "
-                                       "dimensions of data (3)")):
-        SphericalHarmonicTimeData(
-            data, times,  basis_type='real', normalization='SN3D',
-            channel_convention="ACN", condon_shortley=False,
-            comment="", sh_caxis=-4)
+            comment="", caxis_spherical_harmonics=-4)
 
 
 def test_init_sh_frequency_data_wrong_sh_caxis():
@@ -137,16 +133,10 @@ def test_init_sh_frequency_data_wrong_sh_caxis():
     frequencies = [1, 2, 3, 4]
 
     with pytest.raises(ValueError,
-                       match="sh_caxis has to be a negative integer."):
+                       match=re.escape("caxis_spherical_harmonics (-4) "
+                                       "exceeds the number of dimensions of "
+                                       "data (3)")):
         SphericalHarmonicFrequencyData(
             data, frequencies, basis_type='real', normalization='SN3D',
             channel_convention="ACN", condon_shortley=False,
-            comment="", sh_caxis=1)
-
-    with pytest.raises(ValueError,
-                       match=re.escape("sh_caxis (-4) exceeds the number of "
-                                       "dimensions of data (3)")):
-        SphericalHarmonicFrequencyData(
-            data, frequencies, basis_type='real', normalization='SN3D',
-            channel_convention="ACN", condon_shortley=False,
-            comment="", sh_caxis=-4)
+            comment="", caxis_spherical_harmonics=-4)

--- a/tests/test_spherical_harmonics_audio.py
+++ b/tests/test_spherical_harmonics_audio.py
@@ -6,6 +6,7 @@ from spharpy import SphericalHarmonicDefinition
 import numpy as np
 import numpy.testing as npt
 import pytest
+import re
 
 
 def test_atleast_3d_data():
@@ -122,6 +123,13 @@ def test_init_sh_time_data_wrong_sh_caxis():
             data, times,  basis_type='real', normalization='SN3D',
             channel_convention="ACN", condon_shortley=False,
             comment="", sh_caxis=1)
+    with pytest.raises(ValueError,
+                       match=re.escape("sh_caxis (-4) exceeds the number of "
+                                       "dimensions of data (3)")):
+        SphericalHarmonicTimeData(
+            data, times,  basis_type='real', normalization='SN3D',
+            channel_convention="ACN", condon_shortley=False,
+            comment="", sh_caxis=-4)
 
 
 def test_init_sh_frequency_data_wrong_sh_caxis():
@@ -134,3 +142,11 @@ def test_init_sh_frequency_data_wrong_sh_caxis():
             data, frequencies, basis_type='real', normalization='SN3D',
             channel_convention="ACN", condon_shortley=False,
             comment="", sh_caxis=1)
+
+    with pytest.raises(ValueError,
+                       match=re.escape("sh_caxis (-4) exceeds the number of "
+                                       "dimensions of data (3)")):
+        SphericalHarmonicFrequencyData(
+            data, frequencies, basis_type='real', normalization='SN3D',
+            channel_convention="ACN", condon_shortley=False,
+            comment="", sh_caxis=-4)

--- a/tests/test_spherical_harmonics_signal.py
+++ b/tests/test_spherical_harmonics_signal.py
@@ -111,6 +111,19 @@ def test_spherical_harmonic_signal_init_multichannel():
     assert isinstance(signal, SphericalHarmonicSignal)
 
 
+def test_spherical_harmonic_signal_init_non_default_axis():
+    """Test init SphercalHarmonicsSignal."""
+    sh_coeffs = np.zeros((4, 2, 16))
+    signal = SphericalHarmonicSignal(sh_coeffs,
+                                     44100, basis_type='real',
+                                     channel_convention='ACN',
+                                     normalization='N3D',
+                                     condon_shortley=False,
+                                     sh_caxis=-3)
+    assert isinstance(signal, SphericalHarmonicSignal)
+    assert signal.sh_caxis == -3
+
+
 def test_nmax_getter():
     """Test nmax getter."""
     data = np.array([[1., 2., 3.],
@@ -121,10 +134,23 @@ def test_nmax_getter():
                                      44100, basis_type='real',
                                      channel_convention='ACN',
                                      normalization='N3D',
-                                     condon_shortley=False,
-                                     sh_caxis=-2)
+                                     condon_shortley=False)
     assert signal.n_max == 1
     assert isinstance(signal.n_max, int)
+
+
+def test_default_sh_caxis_getter():
+    """Test sh_caxis getter"""
+    data = np.array([[1., 2., 3.],
+                     [1., 2., 3.],
+                     [1., 2., 3.],
+                     [1., 2., 3.]]).reshape(1, 4, 3)
+    signal = SphericalHarmonicSignal(data,
+                                     44100, basis_type='real',
+                                     channel_convention='ACN',
+                                     normalization='N3D',
+                                     condon_shortley=False)
+    assert signal.sh_caxis == -2
 
 
 def test_init_wrong_basis_type():

--- a/tests/test_spherical_harmonics_signal.py
+++ b/tests/test_spherical_harmonics_signal.py
@@ -17,7 +17,7 @@ def test_spherical_harmonic_signal_init():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-2)
+                                     sh_caxis=-1)
     assert isinstance(signal, SphericalHarmonicSignal)
 
 
@@ -45,7 +45,7 @@ def test_sh_signal_from_sh_definition():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-2)
+                                     sh_caxis=-1)
     assert signal_def == signal
 
 
@@ -64,7 +64,7 @@ def test_spherical_harmonic_signal_init_condon_shortley():
                                      channel_convention='ACN',
                                      condon_shortley=False,
                                      normalization='N3D',
-                                     sh_caxis=-2)
+                                     sh_caxis=-1)
     assert not signal.condon_shortley
 
     signal = SphericalHarmonicSignal(data.astype(np.complex128),
@@ -73,7 +73,7 @@ def test_spherical_harmonic_signal_init_condon_shortley():
                                      normalization='N3D',
                                      condon_shortley=True,
                                      is_complex=True,
-                                     sh_caxis=-2)
+                                     sh_caxis=-1)
     assert signal.condon_shortley
 
 
@@ -96,7 +96,7 @@ def test_spherical_harmonic_signal_wrong_dimensions():
                                 channel_convention='ACN',
                                 condon_shortley=False,
                                 normalization='N3D',
-                                sh_caxis=-2)
+                                sh_caxis=-1)
 
 
 def test_spherical_harmonic_signal_init_multichannel():
@@ -107,7 +107,7 @@ def test_spherical_harmonic_signal_init_multichannel():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-2)
+                                     sh_caxis=-1)
     assert isinstance(signal, SphericalHarmonicSignal)
 
 
@@ -134,9 +134,9 @@ def test_spherical_harmonic_signal_init_non_default_axis():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-3)
+                                     sh_caxis=-2)
     assert isinstance(signal, SphericalHarmonicSignal)
-    assert signal.sh_caxis == -3
+    assert signal.sh_caxis == -2
 
 
 def test_default_sh_caxis_getter():
@@ -150,7 +150,7 @@ def test_default_sh_caxis_getter():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False)
-    assert signal.sh_caxis == -2
+    assert signal.sh_caxis == -1
 
 
 def test_init_wrong_basis_type():
@@ -166,7 +166,7 @@ def test_init_wrong_basis_type():
                                 channel_convention='ACN',
                                 normalization='N3D',
                                 condon_shortley=False,
-                                sh_caxis=-2)
+                                sh_caxis=-1)
 
 
 def test_basis_type_getter():
@@ -180,7 +180,7 @@ def test_basis_type_getter():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-2)
+                                     sh_caxis=-1)
     assert signal.basis_type == 'real'
 
 
@@ -198,7 +198,7 @@ def test_init_wrong_normalization():
                                 channel_convention='ACN',
                                 normalization='invalid_normalization',
                                 condon_shortley=False,
-                                sh_caxis=-2)
+                                sh_caxis=-1)
 
 
 def test_spherical_harmonic_signal_normalization_setter():
@@ -211,7 +211,7 @@ def test_spherical_harmonic_signal_normalization_setter():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-2)
+                                     sh_caxis=-1)
     signal.normalization = 'SN3D'
     assert signal.normalization == 'SN3D'
 
@@ -243,7 +243,7 @@ def test_init_wrong_channel_convention():
                                 channel_convention='invalid_convention',
                                 normalization='N3D',
                                 condon_shortley=False,
-                                sh_caxis=-2)
+                                sh_caxis=-1)
 
 
 def test_spherical_harmonic_signal_channel_convention_setter():
@@ -256,7 +256,7 @@ def test_spherical_harmonic_signal_channel_convention_setter():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-2)
+                                     sh_caxis=-1)
     signal.channel_convention = 'FuMa'
     assert signal.channel_convention == 'FuMa'
 
@@ -274,7 +274,7 @@ def test_spherical_harmonic_signal_change_channel_convention():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-2)
+                                     sh_caxis=-1)
     signal.channel_convention = 'FuMa'
     assert signal.channel_convention == 'FuMa'
 
@@ -291,7 +291,7 @@ def test_spherical_harmonic_signal_renormalize():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-2)
+                                     sh_caxis=-1)
     signal.normalization = 'maxN'
     data_ref = np.array([[np.sqrt(1 / 2), np.sqrt(1 / 2)],
                          [np.sqrt(1 / 3), np.sqrt(1 / 3)],

--- a/tests/test_spherical_harmonics_signal.py
+++ b/tests/test_spherical_harmonics_signal.py
@@ -16,7 +16,8 @@ def test_spherical_harmonic_signal_init():
                                      44100, basis_type='real',
                                      channel_convention='ACN',
                                      normalization='N3D',
-                                     condon_shortley=False)
+                                     condon_shortley=False,
+                                     sh_caxis=-2)
     assert isinstance(signal, SphericalHarmonicSignal)
 
 
@@ -43,7 +44,8 @@ def test_sh_signal_from_sh_definition():
                                      44100, basis_type='real',
                                      channel_convention='ACN',
                                      normalization='N3D',
-                                     condon_shortley=False)
+                                     condon_shortley=False,
+                                     sh_caxis=-2)
     assert signal_def == signal
 
 
@@ -61,7 +63,8 @@ def test_spherical_harmonic_signal_init_condon_shortley():
                                      44100, basis_type='real',
                                      channel_convention='ACN',
                                      condon_shortley=False,
-                                     normalization='N3D')
+                                     normalization='N3D',
+                                     sh_caxis=-2)
     assert not signal.condon_shortley
 
     signal = SphericalHarmonicSignal(data.astype(np.complex128),
@@ -69,7 +72,8 @@ def test_spherical_harmonic_signal_init_condon_shortley():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=True,
-                                     is_complex=True)
+                                     is_complex=True,
+                                     sh_caxis=-2)
     assert signal.condon_shortley
 
 
@@ -91,7 +95,8 @@ def test_spherical_harmonic_signal_wrong_dimensions():
                                 44100, basis_type='real',
                                 channel_convention='ACN',
                                 condon_shortley=False,
-                                normalization='N3D')
+                                normalization='N3D',
+                                sh_caxis=-2)
 
 
 def test_spherical_harmonic_signal_init_multichannel():
@@ -101,7 +106,8 @@ def test_spherical_harmonic_signal_init_multichannel():
                                      44100, basis_type='real',
                                      channel_convention='ACN',
                                      normalization='N3D',
-                                     condon_shortley=False)
+                                     condon_shortley=False,
+                                     sh_caxis=-2)
     assert isinstance(signal, SphericalHarmonicSignal)
 
 
@@ -115,7 +121,8 @@ def test_nmax_getter():
                                      44100, basis_type='real',
                                      channel_convention='ACN',
                                      normalization='N3D',
-                                     condon_shortley=False)
+                                     condon_shortley=False,
+                                     sh_caxis=-2)
     assert signal.n_max == 1
     assert isinstance(signal.n_max, int)
 
@@ -132,7 +139,8 @@ def test_init_wrong_basis_type():
                                 44100, basis_type='invalid_basis_type',
                                 channel_convention='ACN',
                                 normalization='N3D',
-                                condon_shortley=False)
+                                condon_shortley=False,
+                                sh_caxis=-2)
 
 
 def test_basis_type_getter():
@@ -145,7 +153,8 @@ def test_basis_type_getter():
                                      44100, basis_type='real',
                                      channel_convention='ACN',
                                      normalization='N3D',
-                                     condon_shortley=False)
+                                     condon_shortley=False,
+                                     sh_caxis=-2)
     assert signal.basis_type == 'real'
 
 
@@ -162,7 +171,8 @@ def test_init_wrong_normalization():
                                 44100, basis_type='real',
                                 channel_convention='ACN',
                                 normalization='invalid_normalization',
-                                condon_shortley=False)
+                                condon_shortley=False,
+                                sh_caxis=-2)
 
 
 def test_spherical_harmonic_signal_normalization_setter():
@@ -174,7 +184,8 @@ def test_spherical_harmonic_signal_normalization_setter():
                                      44100, basis_type='real',
                                      channel_convention='ACN',
                                      normalization='N3D',
-                                     condon_shortley=False)
+                                     condon_shortley=False,
+                                     sh_caxis=-2)
     signal.normalization = 'SN3D'
     assert signal.normalization == 'SN3D'
 
@@ -205,7 +216,8 @@ def test_init_wrong_channel_convention():
                                 44100, basis_type='real',
                                 channel_convention='invalid_convention',
                                 normalization='N3D',
-                                condon_shortley=False)
+                                condon_shortley=False,
+                                sh_caxis=-2)
 
 
 def test_spherical_harmonic_signal_channel_convention_setter():
@@ -217,7 +229,8 @@ def test_spherical_harmonic_signal_channel_convention_setter():
                                      44100, basis_type='real',
                                      channel_convention='ACN',
                                      normalization='N3D',
-                                     condon_shortley=False)
+                                     condon_shortley=False,
+                                     sh_caxis=-2)
     signal.channel_convention = 'FuMa'
     assert signal.channel_convention == 'FuMa'
 
@@ -234,7 +247,8 @@ def test_spherical_harmonic_signal_change_channel_convention():
                                      44100, basis_type='real',
                                      channel_convention='ACN',
                                      normalization='N3D',
-                                     condon_shortley=False)
+                                     condon_shortley=False,
+                                     sh_caxis=-2)
     signal.channel_convention = 'FuMa'
     assert signal.channel_convention == 'FuMa'
 
@@ -250,7 +264,8 @@ def test_spherical_harmonic_signal_renormalize():
                                      44100, basis_type='real',
                                      channel_convention='ACN',
                                      normalization='N3D',
-                                     condon_shortley=False)
+                                     condon_shortley=False,
+                                     sh_caxis=-2)
     signal.normalization = 'maxN'
     data_ref = np.array([[np.sqrt(1 / 2), np.sqrt(1 / 2)],
                          [np.sqrt(1 / 3), np.sqrt(1 / 3)],

--- a/tests/test_spherical_harmonics_signal.py
+++ b/tests/test_spherical_harmonics_signal.py
@@ -300,3 +300,19 @@ def test_spherical_harmonic_signal_renormalize():
 
     np.testing.assert_equal(signal.time,
                             data_ref)
+
+
+def test_init_spherical_harmonic_signal_wrong_sh_caxis():
+    data = np.array([[1., 2., 3.],
+                     [1., 2., 3.],
+                     [1., 2., 3.],
+                     [1., 2., 3.]]).reshape(1, 4, 3)
+
+    with pytest.raises(ValueError,
+                       match="sh_caxis has to be a negative integer."):
+        SphericalHarmonicSignal(data,
+                                44100, basis_type='real',
+                                channel_convention='ACN',
+                                normalization='N3D',
+                                condon_shortley=False,
+                                sh_caxis=1)

--- a/tests/test_spherical_harmonics_signal.py
+++ b/tests/test_spherical_harmonics_signal.py
@@ -111,19 +111,6 @@ def test_spherical_harmonic_signal_init_multichannel():
     assert isinstance(signal, SphericalHarmonicSignal)
 
 
-def test_spherical_harmonic_signal_init_non_default_axis():
-    """Test init SphercalHarmonicsSignal."""
-    sh_coeffs = np.zeros((4, 2, 16))
-    signal = SphericalHarmonicSignal(sh_coeffs,
-                                     44100, basis_type='real',
-                                     channel_convention='ACN',
-                                     normalization='N3D',
-                                     condon_shortley=False,
-                                     sh_caxis=-3)
-    assert isinstance(signal, SphericalHarmonicSignal)
-    assert signal.sh_caxis == -3
-
-
 def test_nmax_getter():
     """Test nmax getter."""
     data = np.array([[1., 2., 3.],
@@ -137,6 +124,19 @@ def test_nmax_getter():
                                      condon_shortley=False)
     assert signal.n_max == 1
     assert isinstance(signal.n_max, int)
+
+
+def test_spherical_harmonic_signal_init_non_default_axis():
+    """Test init SphercalHarmonicsSignal."""
+    sh_coeffs = np.zeros((4, 2, 16))
+    signal = SphericalHarmonicSignal(sh_coeffs,
+                                     44100, basis_type='real',
+                                     channel_convention='ACN',
+                                     normalization='N3D',
+                                     condon_shortley=False,
+                                     sh_caxis=-3)
+    assert isinstance(signal, SphericalHarmonicSignal)
+    assert signal.sh_caxis == -3
 
 
 def test_default_sh_caxis_getter():

--- a/tests/test_spherical_harmonics_signal.py
+++ b/tests/test_spherical_harmonics_signal.py
@@ -17,7 +17,7 @@ def test_spherical_harmonic_signal_init():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-1)
+                                     caxis_spherical_harmonics=-1)
     assert isinstance(signal, SphericalHarmonicSignal)
 
 
@@ -45,7 +45,7 @@ def test_sh_signal_from_sh_definition():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-1)
+                                     caxis_spherical_harmonics=-1)
     assert signal_def == signal
 
 
@@ -64,7 +64,7 @@ def test_spherical_harmonic_signal_init_condon_shortley():
                                      channel_convention='ACN',
                                      condon_shortley=False,
                                      normalization='N3D',
-                                     sh_caxis=-1)
+                                     caxis_spherical_harmonics=-1)
     assert not signal.condon_shortley
 
     signal = SphericalHarmonicSignal(data.astype(np.complex128),
@@ -73,7 +73,7 @@ def test_spherical_harmonic_signal_init_condon_shortley():
                                      normalization='N3D',
                                      condon_shortley=True,
                                      is_complex=True,
-                                     sh_caxis=-1)
+                                     caxis_spherical_harmonics=-1)
     assert signal.condon_shortley
 
 
@@ -96,7 +96,7 @@ def test_spherical_harmonic_signal_wrong_dimensions():
                                 channel_convention='ACN',
                                 condon_shortley=False,
                                 normalization='N3D',
-                                sh_caxis=-1)
+                                caxis_spherical_harmonics=-1)
 
 
 def test_spherical_harmonic_signal_init_multichannel():
@@ -107,7 +107,7 @@ def test_spherical_harmonic_signal_init_multichannel():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-1)
+                                     caxis_spherical_harmonics=-1)
     assert isinstance(signal, SphericalHarmonicSignal)
 
 
@@ -134,9 +134,9 @@ def test_spherical_harmonic_signal_init_non_default_axis():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-2)
+                                     caxis_spherical_harmonics=-2)
     assert isinstance(signal, SphericalHarmonicSignal)
-    assert signal.sh_caxis == -2
+    assert signal.caxis_spherical_harmonics == -2
 
 
 def test_default_sh_caxis_getter():
@@ -150,7 +150,7 @@ def test_default_sh_caxis_getter():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False)
-    assert signal.sh_caxis == -1
+    assert signal.caxis_spherical_harmonics == -1
 
 
 def test_init_wrong_basis_type():
@@ -166,7 +166,7 @@ def test_init_wrong_basis_type():
                                 channel_convention='ACN',
                                 normalization='N3D',
                                 condon_shortley=False,
-                                sh_caxis=-1)
+                                caxis_spherical_harmonics=-1)
 
 
 def test_basis_type_getter():
@@ -180,7 +180,7 @@ def test_basis_type_getter():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-1)
+                                     caxis_spherical_harmonics=-1)
     assert signal.basis_type == 'real'
 
 
@@ -198,7 +198,7 @@ def test_init_wrong_normalization():
                                 channel_convention='ACN',
                                 normalization='invalid_normalization',
                                 condon_shortley=False,
-                                sh_caxis=-1)
+                                caxis_spherical_harmonics=-1)
 
 
 def test_spherical_harmonic_signal_normalization_setter():
@@ -211,7 +211,7 @@ def test_spherical_harmonic_signal_normalization_setter():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-1)
+                                     caxis_spherical_harmonics=-1)
     signal.normalization = 'SN3D'
     assert signal.normalization == 'SN3D'
 
@@ -243,7 +243,7 @@ def test_init_wrong_channel_convention():
                                 channel_convention='invalid_convention',
                                 normalization='N3D',
                                 condon_shortley=False,
-                                sh_caxis=-1)
+                                caxis_spherical_harmonics=-1)
 
 
 def test_spherical_harmonic_signal_channel_convention_setter():
@@ -256,7 +256,7 @@ def test_spherical_harmonic_signal_channel_convention_setter():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-1)
+                                     caxis_spherical_harmonics=-1)
     signal.channel_convention = 'FuMa'
     assert signal.channel_convention == 'FuMa'
 
@@ -274,7 +274,7 @@ def test_spherical_harmonic_signal_change_channel_convention():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-1)
+                                     caxis_spherical_harmonics=-1)
     signal.channel_convention = 'FuMa'
     assert signal.channel_convention == 'FuMa'
 
@@ -291,7 +291,7 @@ def test_spherical_harmonic_signal_renormalize():
                                      channel_convention='ACN',
                                      normalization='N3D',
                                      condon_shortley=False,
-                                     sh_caxis=-1)
+                                     caxis_spherical_harmonics=-1)
     signal.normalization = 'maxN'
     data_ref = np.array([[np.sqrt(1 / 2), np.sqrt(1 / 2)],
                          [np.sqrt(1 / 3), np.sqrt(1 / 3)],
@@ -302,27 +302,19 @@ def test_spherical_harmonic_signal_renormalize():
                             data_ref)
 
 
-def test_init_spherical_harmonic_signal_wrong_sh_caxis():
+def test_sh_signal_init_wrong_caxis_spherical_harmonics():
     data = np.array([[1., 2., 3.],
                      [1., 2., 3.],
                      [1., 2., 3.],
                      [1., 2., 3.]]).reshape(1, 4, 3)
 
     with pytest.raises(ValueError,
-                       match="sh_caxis has to be a negative integer."):
+                       match=re.escape("caxis_spherical_harmonics (-4) "
+                                       "exceeds the number of dimensions of "
+                                       "data (3)")):
         SphericalHarmonicSignal(data,
                                 44100, basis_type='real',
                                 channel_convention='ACN',
                                 normalization='N3D',
                                 condon_shortley=False,
-                                sh_caxis=1)
-
-    with pytest.raises(ValueError,
-                       match=re.escape("sh_caxis (-4) exceeds the number of "
-                                       "dimensions of data (3)")):
-        SphericalHarmonicSignal(data,
-                                44100, basis_type='real',
-                                channel_convention='ACN',
-                                normalization='N3D',
-                                condon_shortley=False,
-                                sh_caxis=-4)
+                                caxis_spherical_harmonics=-4)

--- a/tests/test_spherical_harmonics_signal.py
+++ b/tests/test_spherical_harmonics_signal.py
@@ -316,3 +316,13 @@ def test_init_spherical_harmonic_signal_wrong_sh_caxis():
                                 normalization='N3D',
                                 condon_shortley=False,
                                 sh_caxis=1)
+
+    with pytest.raises(ValueError,
+                       match=re.escape("sh_caxis (-4) exceeds the number of "
+                                       "dimensions of data (3)")):
+        SphericalHarmonicSignal(data,
+                                44100, basis_type='real',
+                                channel_convention='ACN',
+                                normalization='N3D',
+                                condon_shortley=False,
+                                sh_caxis=-4)

--- a/tests/test_spherical_harmonics_signal.py
+++ b/tests/test_spherical_harmonics_signal.py
@@ -153,6 +153,19 @@ def test_default_sh_caxis_getter():
     assert signal.caxis_spherical_harmonics == -1
 
 
+def test_multichannel_spherical_harmonic_caxis_sh_getter():
+    """Test init SphercalHarmonicsSignal."""
+    sh_coeffs = np.zeros((4, 4, 2, 16))
+    signal = SphericalHarmonicSignal(sh_coeffs,
+                                     44100, basis_type='real',
+                                     channel_convention='ACN',
+                                     normalization='N3D',
+                                     condon_shortley=False,
+                                     caxis_spherical_harmonics=(-3, -2))
+    assert isinstance(signal, SphericalHarmonicSignal)
+    assert signal.caxis_spherical_harmonics == (-3, -2)
+
+
 def test_init_wrong_basis_type():
     data = np.array([[1., 2., 3.],
                      [1., 2., 3.],

--- a/tests/test_spherical_harmonics_signal.py
+++ b/tests/test_spherical_harmonics_signal.py
@@ -140,7 +140,7 @@ def test_spherical_harmonic_signal_init_non_default_axis():
 
 
 def test_default_sh_caxis_getter():
-    """Test sh_caxis getter"""
+    """Test sh_caxis getter."""
     data = np.array([[1., 2., 3.],
                      [1., 2., 3.],
                      [1., 2., 3.],


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #326

### Changes proposed in this pull request:

- Introduce property `caxis_spherical_harmonics` in `_SphericalHarmonicsAudio`, `SphericalHarmonicTimeData` , `SphericalHarmonicFrequencyData`, and `SphericalHarmonicSignal` which defines the axis along which SHSignals  store SH coefficients
- Adapt rotation accordingly
- allow `caxis_spherical_harmonics` property for multichannel SH data
